### PR TITLE
Update mapbox-gl version in the cms map plugin

### DIFF
--- a/cms/src/plugins/map-field/package.json
+++ b/cms/src/plugins/map-field/package.json
@@ -11,7 +11,7 @@
     "@strapi/design-system": "^1.9.0",
     "@strapi/helper-plugin": "4.11.2",
     "@strapi/icons": "^1.6.3",
-    "mapbox-gl": "2.15.0",
+    "mapbox-gl": "3.0.1",
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-map-gl": "^7.1.5"

--- a/cms/src/plugins/map-field/yarn.lock
+++ b/cms/src/plugins/map-field/yarn.lock
@@ -1701,6 +1701,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cheap-ruler@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "cheap-ruler@npm:3.0.2"
+  checksum: 7e3b4f593e2baa3fc5a140f461c399f876b33b76930cf540f06673c1470c3ab0782aef668394392406ecaabae36161879813ba6ad2e8e5ee146faa32298502ba
+  languageName: node
+  linkType: hard
+
 "cli-table3@npm:0.6.2":
   version: 0.6.2
   resolution: "cli-table3@npm:0.6.2"
@@ -2367,7 +2374,7 @@ __metadata:
     "@types/react-router": ^5.1.20
     "@types/react-router-dom": ^5.3.3
     "@types/styled-components": ^5.1.26
-    mapbox-gl: 2.15.0
+    mapbox-gl: 3.0.1
     prop-types: ^15.7.2
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -2382,9 +2389,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"mapbox-gl@npm:2.15.0":
-  version: 2.15.0
-  resolution: "mapbox-gl@npm:2.15.0"
+"mapbox-gl@npm:3.0.1":
+  version: 3.0.1
+  resolution: "mapbox-gl@npm:3.0.1"
   dependencies:
     "@mapbox/geojson-rewind": ^0.5.2
     "@mapbox/jsonlint-lines-primitives": ^2.0.2
@@ -2394,6 +2401,7 @@ __metadata:
     "@mapbox/unitbezier": ^0.0.1
     "@mapbox/vector-tile": ^1.3.1
     "@mapbox/whoots-js": ^3.1.0
+    cheap-ruler: ^3.0.1
     csscolorparser: ~1.0.3
     earcut: ^2.2.4
     geojson-vt: ^3.2.1
@@ -2408,7 +2416,7 @@ __metadata:
     supercluster: ^8.0.0
     tinyqueue: ^2.0.3
     vt-pbf: ^3.1.3
-  checksum: 4a2303170cc3e703fb4a3d9866bb4b8000af6975977f220d03d063bfe40edf8ebc5dd72eee18e05a9bf5644c655c151a09529880bb9ca5df62cb1235ef2ef05f
+  checksum: cbb1c93aaeb24fed11a2c69d7aeada2e0271c90fc52c54a9d64cd8a20149cd4a6529c3551cc38342573cb39fba8a74389078e41c6a98fbf7847cb649f1601a2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the mapboxgl version in the CMS map plugin to support new map style