### PR TITLE
bug fix autoplay

### DIFF
--- a/client/src/components/map/legend/item-types/timeline/index.tsx
+++ b/client/src/components/map/legend/item-types/timeline/index.tsx
@@ -47,7 +47,6 @@ export const LegendTypeTimeline: React.FC<LegendTypeTimelineProps> = ({
   const [timelines, setTimelines] = useAtom(timelineAtom);
 
   const frame = useMemo(() => timelines[id]?.frame || 0, [id, timelines]);
-
   const TIMELINE = useMemo(() => {
     if (!start || !end) return [];
 
@@ -110,7 +109,7 @@ export const LegendTypeTimeline: React.FC<LegendTypeTimelineProps> = ({
         frame,
       },
     }));
-  }, [id, layerId, setTimelines, frame]);
+  }, [id, layerId, setTimelines]);
 
   const setFrame = useCallback(
     (f: number) => {
@@ -191,8 +190,19 @@ export const LegendTypeTimeline: React.FC<LegendTypeTimelineProps> = ({
   const maxValue = TIMELINE?.length - 1 || 1;
   const minValue = 0;
 
+  // TO - DO - improve the way we handle intervals
   useEffect(() => {
     handlePlay();
+
+    return () => {
+      clearInterval(interval);
+      setFrame(0);
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const interval_id = window.setInterval(() => {}, Number.MAX_SAFE_INTEGER);
+      for (let i = 1; i < interval_id; i++) {
+        window.clearInterval(i);
+      }
+    };
   }, []);
 
   // If the layer is not the first one in the timeline, don't render the component


### PR DESCRIPTION
This pull request introduces debugging and cleanup changes to the `LegendTypeTimeline` component in `index.tsx`, as well as some adjustments to how intervals are managed when the component unmounts. The main focus is on improving interval cleanup and adding debugging output.

Interval and effect management:

* Improved interval cleanup in the `useEffect` hook by ensuring all intervals are cleared and the frame is reset to 0 when the component unmounts. This includes a loop to clear any stray intervals that may exist.
* Added a comment noting the need to improve how intervals are handled in the future.

Dependency and code cleanup:

* Removed `frame` from the dependency array of a `useEffect` hook that updates the timeline state, likely to prevent unnecessary updates.