### PR TITLE
fix hyperlinks

### DIFF
--- a/client/src/components/ui/rich-text.tsx
+++ b/client/src/components/ui/rich-text.tsx
@@ -18,7 +18,7 @@ const RichText = ({ children, className }: RichTextProps) => {
   return (
     <Markdown
       components={{
-        a: ({ node, href, ...props }) => (
+        a: ({ node, ...props }) => (
           <a {...props} target="_blank" className="underline">
             {props.children}
           </a>


### PR DESCRIPTION
This pull request makes a minor update to the `RichText` component to simplify the handling of anchor tags. The unnecessary `href` prop is removed from the destructuring in the custom anchor (`a`) component, which helps clean up the code.