### PR TITLE
esa new styles

### DIFF
--- a/client/src/containers/story/steps/layouts/map-step.tsx
+++ b/client/src/containers/story/steps/layouts/map-step.tsx
@@ -30,8 +30,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 import MapContent from './components/map-content';
 
-import Image from 'next/image';
-
 const MapLegends = dynamic(() => import('@/containers/map/legend'), {
   ssr: false,
 });
@@ -50,12 +48,14 @@ type MapStepLayoutProps = {
     name: string;
     content: string;
     image: {
-      data: {
-        attributes: {
-          url: string;
-          image: string;
-        }[];
-      } | null;
+      data:
+        | {
+            attributes: {
+              url: string;
+              image: string;
+            };
+          }[]
+        | null;
     } | null;
   };
 };
@@ -82,7 +82,7 @@ const MapStepLayout = ({ step, showContent, storySummary }: MapStepLayoutProps) 
   // const handleClickMarker = (markerIndex: number) => {
   //   setCurrentMedia(markerIndex);
   // };
-  console.log(quote, quote?.image?.data?.[0]?.attributes?.url);
+
   return (
     <div className="flex justify-end">
       <div
@@ -137,7 +137,7 @@ const MapStepLayout = ({ step, showContent, storySummary }: MapStepLayoutProps) 
                     style={{
                       backgroundImage: `url(${getImageSrc(
                         quote?.image?.data?.[0]?.attributes?.url ||
-                          quote.image?.data?.attributes?.image
+                          quote.image?.data?.[0]?.attributes?.image
                       )})`,
                     }}
                   />

--- a/cms/src/api/category/content-types/category/schema.json
+++ b/cms/src/api/category/content-types/category/schema.json
@@ -33,6 +33,9 @@
       "type": "component",
       "repeatable": true,
       "component": "partners.partners"
+    },
+    "url": {
+      "type": "string"
     }
   }
 }

--- a/cms/src/api/story/content-types/story/schema.json
+++ b/cms/src/api/story/content-types/story/schema.json
@@ -73,11 +73,12 @@
       "type": "string"
     },
     "cover_image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     }
   }
 }

--- a/cms/src/components/quote/quote.json
+++ b/cms/src/components/quote/quote.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_quote_quotes",
+  "info": {
+    "displayName": "quote"
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": true
+    }
+  }
+}

--- a/cms/src/components/step-layout/map-step.json
+++ b/cms/src/components/step-layout/map-step.json
@@ -30,6 +30,12 @@
       "type": "component",
       "repeatable": false,
       "component": "widget.widget"
+    },
+    "quote": {
+      "displayName": "quote",
+      "type": "component",
+      "repeatable": false,
+      "component": "quote.quote"
     }
   }
 }


### PR DESCRIPTION
This pull request introduces several updates to both the CMS schema and the frontend codebase to support richer quote content in map steps, improve type safety, and enhance media handling. The main changes are the addition of a reusable `quote` component with media support, schema updates to reference this component, and frontend adjustments to handle the new data structure.

### CMS schema and component updates

* Added a new `quote` component (`cms/src/components/quote/quote.json`) that supports a name, richtext content, and multiple media types (images, files, videos, audios).
* Updated the `map-step` component schema (`cms/src/components/step-layout/map-step.json`) to include the new `quote` component as a field, allowing map steps to reference quotes.
* Added a `url` string field to the `category` schema (`cms/src/api/category/content-types/category/schema.json`) for additional metadata.
* Refactored the `cover_image` field in the `story` schema (`cms/src/api/story/content-types/story/schema.json`) for clarity and improved type definition.

### Frontend code and type improvements

* Updated the `MapStepLayoutProps` type in `client/src/containers/story/steps/layouts/map-step.tsx` to accurately reflect the new structure of the `quote.image.data` field, supporting arrays and null values for better type safety.
* Fixed frontend logic in `client/src/containers/story/steps/layouts/map-step.tsx` to correctly access quote image data, using array indexing and updated property paths to match the new schema.
* Removed unused imports and cleaned up debug logging in `client/src/containers/story/steps/layouts/map-step.tsx` for code clarity. [[1]](diffhunk://#diff-94b857cf81288743ca2cf82897aff19067606025b916580f488f84a02b52f0b3L33-L34) [[2]](diffhunk://#diff-94b857cf81288743ca2cf82897aff19067606025b916580f488f84a02b52f0b3L85-R85)