### PR TITLE
quote image

### DIFF
--- a/client/src/containers/story/steps/layouts/map-step.tsx
+++ b/client/src/containers/story/steps/layouts/map-step.tsx
@@ -132,15 +132,17 @@ const MapStepLayout = ({ step, showContent, storySummary }: MapStepLayoutProps) 
                   <RichText>{quote.content}</RichText>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <div
-                    className="border-primary flex h-14 w-14 shrink-0 rounded-full border bg-cover bg-top bg-no-repeat"
-                    style={{
-                      backgroundImage: `url(${getImageSrc(
-                        quote?.image?.data?.[0]?.attributes?.url ||
-                          quote.image?.data?.[0]?.attributes?.image
-                      )})`,
-                    }}
-                  />
+                  {!!quote?.image?.data?.length && (
+                    <div
+                      className="border-primary flex h-14 w-14 shrink-0 rounded-full border bg-cover bg-top bg-no-repeat"
+                      style={{
+                        backgroundImage: `url(${getImageSrc(
+                          quote?.image?.data?.[0]?.attributes?.url ||
+                            quote.image?.data?.[0]?.attributes?.image
+                        )})`,
+                      }}
+                    />
+                  )}
                   <div className="text-sm">{quote.name}</div>
                 </div>
               </div>


### PR DESCRIPTION
This pull request makes a minor update to the `MapStepLayout` component to improve the conditional rendering of quote images. Now, the image avatar for a quote will only be rendered if image data is present, preventing empty or broken image placeholders.

* Conditional rendering: The quote image avatar in `MapStepLayout` (`map-step.tsx`) is now only displayed if `quote.image.data` exists and has a length, improving UI robustness. [[1]](diffhunk://#diff-94b857cf81288743ca2cf82897aff19067606025b916580f488f84a02b52f0b3R135) [[2]](diffhunk://#diff-94b857cf81288743ca2cf82897aff19067606025b916580f488f84a02b52f0b3R145)