### PR TITLE
top stories limit

### DIFF
--- a/client/src/containers/globe/top-stories/index.tsx
+++ b/client/src/containers/globe/top-stories/index.tsx
@@ -10,6 +10,7 @@ const TopStories = () => {
     populate: 'cover_image,story,story.category',
     sort: 'index:asc',
     filters: { story: { category: { slug: { $eq: category } } } },
+    'pagination[pageSize]': 1000,
   });
 
   return (


### PR DESCRIPTION
This pull request makes a small improvement to the `TopStories` component by increasing the number of stories fetched from the API. The change sets the page size to 1000, ensuring that up to 1000 stories can be retrieved in a single request.

* Increased the `pagination[pageSize]` parameter to 1000 in the API call within `client/src/containers/globe/top-stories/index.tsx` to allow fetching more stories at once.