### PR TITLE
api route

### DIFF
--- a/client/src/hooks/dashboard/index.ts
+++ b/client/src/hooks/dashboard/index.ts
@@ -17,7 +17,8 @@ export function useDashboard<TSelected = DashboardProps>(
   >
 ): UseQueryResult<TSelected, Error> {
   const fetchDashboard = async (): Promise<DashboardProps> => {
-    const res = await fetch('/api/dashboard');
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+    const res = await fetch(`${basePath}/api/dashboard`);
 
     if (!res.ok) {
       throw new Error(`Dashboard API error: ${res.status}`);


### PR DESCRIPTION
This pull request updates the way the dashboard API endpoint is constructed in the `useDashboard` hook to support deployments with a custom base path.

API request improvement:

* Updated the `useDashboard` hook in `client/src/hooks/dashboard/index.ts` to prepend the API request with the `NEXT_PUBLIC_BASE_PATH` environment variable if it exists, ensuring correct API routing in environments with a custom base path.