### PR TITLE
Data/afghanistan cr

### DIFF
--- a/client/src/hooks/dashboard/index.ts
+++ b/client/src/hooks/dashboard/index.ts
@@ -20,7 +20,7 @@ export function useDashboard<TSelected = DashboardProps>(
 ): UseQueryResult<TSelected, Error> {
   const fetchDashboard = async (): Promise<DashboardProps> => {
     const basePath = env.NEXT_PUBLIC_BASE_PATH || '/';
-    const res = await fetch(`${basePath}api/dashboard`);
+    const res = await fetch(`${basePath}/api/dashboard`);
 
     if (!res.ok) {
       throw new Error(`Dashboard API error: ${res.status}`);

--- a/data-processing/src/helpers/mbtiles_converter.py
+++ b/data-processing/src/helpers/mbtiles_converter.py
@@ -160,7 +160,10 @@ class MBTilesConverterFactory:
     ) -> None:
         """Convenience method to convert file using appropriate converter."""
         converter = cls.create_converter(input_path)
-        converter.convert(input_path, output_path, tile_format=tile_format, **kwargs)
+        if isinstance(converter, GeoTIFFConverter):
+            converter.convert(input_path, output_path, tile_format=tile_format, **kwargs)
+        else:
+            converter.convert(input_path, output_path, **kwargs)
 
     @classmethod
     def register_converter(cls, extension: str, converter_class: Type[MBTilesConverter]) -> None:

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -357,3 +357,32 @@ layers:
     layer_name: "Sudan_Water_Points"
     min_zoom: 8
     max_zoom: 12
+
+  # Afghanistan - CR
+  afghanistan_provinces:
+    input_file: "../data/raw/Climate_resilience/Afghanistan/Datasets/Afghanistan_Provinces/AFG_Provinces_4326.shp"
+    output_file: "../data/processed/Climate_resilience/Afghanistan/Provinces.mbtiles"
+    layer_name: "Afghanistan_Provinces"
+    min_zoom: 3
+    max_zoom: 9
+
+  afghanistan_built_surface:
+    input_file: "../data/raw/Climate_resilience/Afghanistan/Datasets/BuiltSurface_Afghanistan/GHS_BuiltSurface_Afghanistan.shp"
+    output_file: "../data/processed/Climate_resilience/Afghanistan/BuiltSurface.mbtiles"
+    layer_name: "Afghanistan_BuiltSurface"
+    min_zoom: 3
+    max_zoom: 9
+
+  afghanistan_flood_risk:
+    input_file: "../data/raw/Climate_resilience/Afghanistan/Datasets/flood_risk/risk_50yrs.shp"
+    output_file: "../data/processed/Climate_resilience/Afghanistan/Flood_Risk_50yrs.mbtiles"
+    layer_name: "Afghanistan_Flood_Risk_50yrs"
+    min_zoom: 3
+    max_zoom: 9
+  
+  afghanistan_exposed_buildings:
+    input_file: "../data/raw/Climate_resilience/Afghanistan/Datasets/JRC_reclassified/50y_poly.shp"
+    output_file: "../data/processed/Climate_resilience/Afghanistan/Exposed_Buildings_50yrs.mbtiles"
+    layer_name: "Afghanistan_Exposed_Buildings_50yrs"
+    min_zoom: 3
+    max_zoom: 9


### PR DESCRIPTION
Fix MBTilesConverterFactory.convert() to avoid passing tile_format to vectors.

Add the layer config of the layers used for CR - Afghanistan.