### PR TITLE
chore: ignore cms/.strapi build cache

### DIFF
--- a/cms/.gitignore
+++ b/cms/.gitignore
@@ -113,6 +113,7 @@ exports
 *.cache
 dist
 build
+.strapi
 .strapi-updater.json
 
 ############################


### PR DESCRIPTION
Adds `.strapi` to `cms/.gitignore`. Strapi 4.x build creates `cms/.strapi/` as cache; should not be tracked.

## Test plan
- [x] Untracked `cms/.strapi/` no longer appears in `git status` after build