### PR TITLE
chore: ignore .claude/ directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ target/
 .tox
 
 .ruff_cache
+
+# Claude Code local config (skills, hooks, settings)
+.claude/


### PR DESCRIPTION
## Summary

  - Create Ruff auto-format hook
  - Create data layer workflow skill
  - Add .claude/ to .gitignore to keep local Claude Code configuration out of the remote repo

 ## Context

  Claude Code stores project-specific configuration in .claude/ at the repo root. This directory currently contains:

  - Ruff auto-format hook (settings.local.json) — automatically runs ruff format and ruff check --fix on Python files in data-processing/ after every edit,  keeping code consistent with the project's Ruff config
  - Data layer workflow skill (skills/data-layer/) — encodes the conventions for adding/processing geospatial layers (which YAML config to edit, which notebook to use,) so Claude follows them without repeated instructions

  These are personal developer tooling configs that shouldn't be committed to the repo so they have been added to .gitignore.