### PR TITLE
data: add Niger CE vector layers and update raster configs

### DIFF
--- a/data-processing/src/raster_config.yaml
+++ b/data-processing/src/raster_config.yaml
@@ -175,28 +175,38 @@ layers:
 
   # Niger - CE
   niger_solar_irradiation:
-    base_path: "../data/raw/Clean Energy/Niger/"
+    base_path: "../data/raw/Clean_energy/Niger/"
     input_file: "Niger_GCS_Buffer25km_250m_Solar_kWhm2_v02.tif"
     style_file: "Niger_GCS_Buffer25km_250m_Solar_kWhm2_v02.qml"
-    output_file: "../data/processed/Clean Energy/Niger/Rasters/Niger_GCS_Buffer25km_250m_Solar_kWhm2_v02.tif"
+    output_file: "../data/processed/Clean_energy/Niger/Rasters/Niger_GCS_Buffer25km_250m_Solar_kWhm2_v02.tif"
     layer_name: "Niger_GCS_Buffer25km_250m_Solar_kWhm2_v02"
     max_zoom: 11
 
+  niger_solar_irradiation_capital:
+      base_path: "../data/raw/Clean_energy/Niger/"
+      input_file: "Niger_SolarRadiation_Mosaic_CapitalRegion.tif"
+      style_file: "Niger_SolarRadiation_Mosaic_CapitalRegion.qml"
+      output_file: "../data/processed/Clean_energy/Niger/Rasters/Niger_SolarRadiation_Mosaic_CapitalRegion.tif"
+      layer_name: "Niger_SolarRadiation_Mosaic_CapitalRegion"
+      max_zoom: 11  
+
   niger_flash_flood_depth:
-    base_path: "../data/raw/Clean Energy/Niger/"
+    base_path: "../data/raw/Clean_energy/Niger/"
     input_file: "Depth_fullAOI.tif"
     style_file: "Depth_fullAOI.qml"
-    output_file: "../data/processed/Clean Energy/Niger/Rasters/Niger_Flash_flood_depth.tif"
+    vector_file: "../data/raw/Clean_energy/Niger/Extent_city.geojson"
+    output_file: "../data/processed/Clean_energy/Niger/Rasters/Niger_Flash_flood_depth.tif"
     layer_name: "Niger_Flash_flood_depth"
-    max_zoom: 11
+    max_zoom: 12
 
   niger_flash_flood_hazard:
-    base_path: "../data/raw/Clean Energy/Niger/"
+    base_path: "../data/raw/Clean_energy/Niger/"
     input_file: "FlashFlood_Hazard_fullAOI_classified.tif"
     style_file: "FlashFlood_Hazard_fullAOI_classified.qml"
-    output_file: "../data/processed/Clean Energy/Niger/Rasters/Niger_Flash_flood_hazard.tif"
+    vector_file: "../data/raw/Clean_energy/Niger/Extent_city.geojson"
+    output_file: "../data/processed/Clean_energy/Niger/Rasters/Niger_Flash_flood_hazard.tif"
     layer_name: "Niger_Flash_flood_hazard"
-    max_zoom: 11
+    max_zoom: 12
 
   # Cote d'Ivoire - Urban
   civ_abidjan_slum_detector:
@@ -276,13 +286,13 @@ layers:
     layer_name: "Cameroon_settlement"
     max_zoom: 11
 
-  cameroon_electrification:
+  cameroon_electrification2:
     base_path: "../data/raw/Clean_energy/Cameroon_Nightlight/"
     input_file: "year_of_electrification_clipped.tif"
     style_file: "year_of_electrification.qml"
-    output_file: "../data/processed/Clean_energy/Cameroon/Rasters/Cameroon_electrification.tif"
-    layer_name: "Cameroon_electrification"
-    max_zoom: 11
+    output_file: "../data/processed/Clean_energy/Cameroon/Rasters/Cameroon_electrification2.tif"
+    layer_name: "Cameroon_electrification2"
+    max_zoom: 15
 
   # Belize - Agriculture
   belize_precipitation:

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -387,6 +387,28 @@ layers:
     min_zoom: 3
     max_zoom: 9
 
+  # Niger - Clean Energy
+  niger_transmission_grid_flood_hazard:
+    input_file: "../data/raw/Clean_energy/Niger/vector_data/Niger_TransmissionGrid_100_FloodHazard.shp"
+    output_file: "../data/processed/Clean_energy/Niger/Vectors/TransmissionGrid_FloodHazard.mbtiles"
+    layer_name: "Niger_TransmissionGrid_FloodHazard"
+    min_zoom: 5
+    max_zoom: 13
+
+  niger_reseau_bt:
+    input_file: "../data/raw/Clean_energy/Niger/vector_data/Reseau_BT.shp"
+    output_file: "../data/processed/Clean_energy/Niger/Vectors/Reseau_BT.mbtiles"
+    layer_name: "Niger_Reseau_BT"
+    min_zoom: 5
+    max_zoom: 13
+
+  niger_reseau_mt:
+    input_file: "../data/raw/Clean_energy/Niger/vector_data/Reseau_MT.shp"
+    output_file: "../data/processed/Clean_energy/Niger/Vectors/Reseau_MT.mbtiles"
+    layer_name: "Niger_Reseau_MT"
+    min_zoom: 5
+    max_zoom: 13
+
   # Nigeria - FCS
   nigeria_districts:
     input_file: "../data/raw/FCS/Nigeria/Vectors/AOI/Districts_merged.geojson"


### PR DESCRIPTION
- Add 3 Niger Clean Energy vector layers (transmission grid, reseau BT/MT)
- Add vector_file clipping for flash flood depth/hazard rasters
- Bump flash flood rasters max_zoom to 12
- Fix Niger CE paths (Clean Energy → Clean_energy)
- Add niger_solar_irradiation_capital layer
- Rename cameroon_electrification → cameroon_electrification2 with max_zoom 15