### PR TITLE
data: add Bhutan health raster and vector layer configs

### DIFF
--- a/data-processing/notebooks/01_raster_layers.ipynb
+++ b/data-processing/notebooks/01_raster_layers.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "# Create raster layers"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -16,10 +18,12 @@
     "\n",
     "The source of truth for all raster layer definitions is `raster_config.yaml`. Most layers run straight from config with no manual steps required and are not documented here.\n",
     "\n",
-    "This notebook documents only layers that needed **custom preprocessing** before running the standard processor — merging tiles, resampling, clipping to boundaries, assigning a missing CRS, etc. These steps are kept for reproducibility and reference.\n",
+    "This notebook documents only layers that needed **custom preprocessing** before running the standard processor \u2014 merging tiles, resampling, clipping to boundaries, assigning a missing CRS, etc. These steps are kept for reproducibility and reference.\n",
     "\n",
     "To process layers that require no preprocessing, use the **working cell** at the bottom of this notebook."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -29,7 +33,9 @@
     "## Setup\n",
     "\n",
     "### Library import"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -60,7 +66,9 @@
    "metadata": {},
    "source": [
     "## Preprocessing records"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -68,7 +76,9 @@
    "metadata": {},
    "source": [
     "#### Somalia - Water"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -178,7 +188,9 @@
    "metadata": {},
    "source": [
     "#### West Africa - Water"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -260,7 +272,9 @@
    "metadata": {},
    "source": [
     "#### Mozambique - Climate Resilience (AGB)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -284,7 +298,7 @@
     "        output_file = input_file.parent / f\"0007MZ_GIL_L4_AGB_{suffix}.tiff\"\n",
     "        with rio.open(output_file, \"w\", **meta) as dst:\n",
     "            dst.write(src.read(i), 1)\n",
-    "        print(f\"{suffix} ({description}) → {output_file}\")"
+    "        print(f\"{suffix} ({description}) \u2192 {output_file}\")"
    ]
   },
   {
@@ -305,7 +319,7 @@
     "    input_file = raw_dir / f\"0007MZ_GIL_L4_AGB_{suffix}.tiff\"\n",
     "    output_file = raw_dir / f\"0007MZ_GIL_L4_AGB_{suffix}_resampled.tiff\"\n",
     "    resample_raster(input_file, output_file, scale_factor=3, resampling_method=Resampling.average)\n",
-    "    print(f\"{suffix} resampled → {output_file}\")"
+    "    print(f\"{suffix} resampled \u2192 {output_file}\")"
    ]
   },
   {
@@ -336,8 +350,10 @@
     "1. Add the layer definition to `raster_config.yaml`\n",
     "2. Edit `layer_keys` below and run\n",
     "3. If preprocessing was needed, move those cells to the **Preprocessing records** section above with a markdown header explaining what was done\n",
-    "4. Revert this cell before committing — do not accumulate processed layer keys here"
-   ]
+    "4. Revert this cell before committing \u2014 do not accumulate processed layer keys here"
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -345,14 +361,7 @@
    "id": "new-working-cell",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\n",
-    "process_raster_layers(\n",
-    "    config_path=config_path,\n",
-    "    layer_keys=[\"your_layer_key_here\"],\n",
-    "    upload_layer_keys=[],\n",
-    ")"
-   ]
+   "source": "# WORKING CELL \u2014 edit layer_keys, run, then revert. Do not commit with real values.\nprocess_raster_layers(\n    config_path=config_path,\n    layer_keys=[\"your_layer_key_here\"],\n    upload_layer_keys=[],\n)"
   }
  ],
  "metadata": {

--- a/data-processing/notebooks/02_vector_layers.ipynb
+++ b/data-processing/notebooks/02_vector_layers.ipynb
@@ -6,12 +6,16 @@
    "metadata": {},
    "source": [
     "# Create vector layers"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "source": "## About this notebook\n\nThe source of truth for all vector layer definitions is `vector_config.yaml`. Most layers run straight from config with no manual steps required and are not documented here.\n\nThis notebook documents only layers that needed **custom preprocessing** before running the standard processor. These steps are kept for reproducibility and reference.\n\nTo process layers that require no preprocessing, use the **working cell** at the bottom of this notebook.",
-   "metadata": {}
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -21,7 +25,9 @@
     "## Setup\n",
     "\n",
     "### Library import"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -43,7 +49,9 @@
    "cell_type": "markdown",
    "id": "cell-3",
    "metadata": {},
-   "source": "## Preprocessing records"
+   "source": "## Preprocessing records",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -51,7 +59,9 @@
    "metadata": {},
    "source": [
     "#### Zambezi basin - Water"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -91,6 +101,20 @@
   },
   {
    "cell_type": "markdown",
+   "source": "#### Bhutan - Health\n\nThe gpkg `GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg` contains two layers (\"Road network\" and \"Health Faciltiies\") that need to be extracted into separate files before processing.",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "source": "gpkg_path = \"../data/raw/Health/Bhutan/Visuals/Step 2/GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg\"\noutput_dir = \"../data/raw/Health/Bhutan/Visuals/Step 2\"\n\nroads = gpd.read_file(gpkg_path, layer=\"Road network\")\nroads.to_file(f\"{output_dir}/Road_network.gpkg\", driver=\"GPKG\")\n\nfacilities = gpd.read_file(gpkg_path, layer=\"Health Faciltiies\")\nfacilities.to_file(f\"{output_dir}/Health_Facilities.gpkg\", driver=\"GPKG\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "new-section-header",
    "metadata": {},
    "source": [
@@ -103,7 +127,9 @@
     "2. Edit `layer_keys` below and run\n",
     "3. If preprocessing was needed, move those cells to the **Preprocessing records** section above with a markdown header explaining what was done\n",
     "4. Revert this cell before committing — do not accumulate processed layer keys here"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -111,14 +137,7 @@
    "id": "new-working-cell",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\n",
-    "process_vector_layers(\n",
-    "    config_path=\"../src/vector_config.yaml\",\n",
-    "    layer_keys=[\"your_layer_key_here\"],\n",
-    "    upload_override=False,\n",
-    ")"
-   ]
+   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_vector_layers(\n    config_path=\"../src/vector_config.yaml\",\n    layer_keys=[\"your_layer_key_here\"],\n    upload_override=False,\n)"
   }
  ],
  "metadata": {

--- a/data-processing/src/data_processing/raster_processor.py
+++ b/data-processing/src/data_processing/raster_processor.py
@@ -201,6 +201,8 @@ class RasterProcessor:
         convert to COG, and optionally to MBTiles and upload to Mapbox.
         """
         try:
+            self.output_file.parent.mkdir(parents=True, exist_ok=True)
+
             if self.vector_file:
                 console.print("✂️ Clipping raster with vector...", style="bold white")
                 self.clip_raster()

--- a/data-processing/src/data_processing/vector_processor.py
+++ b/data-processing/src/data_processing/vector_processor.py
@@ -52,6 +52,7 @@ class VectorProcessor:
         Process the vector data: convert to MBTiles and upload to Mapbox.
         """
         try:
+            self.output_file.parent.mkdir(parents=True, exist_ok=True)
             console.print("📦 Converting to MBTiles...", style="bold white")
             MBTilesConverterFactory.convert(
                 self.input_file,

--- a/data-processing/src/raster_config.yaml
+++ b/data-processing/src/raster_config.yaml
@@ -721,3 +721,44 @@ layers:
     output_file: "../data/processed/FCS/Nigeria/Rasters/Enugu_YearlyChanges_clipped.tif"
     layer_name: "Nigeria_Enugu_YearlyChanges"
     max_zoom: 15
+
+  # Bhutan - Health
+  bhutan_dem:
+    base_path: "../data/raw/Health/Bhutan/Visuals/Step 2"
+    input_file: "GDA-Public-Health_DEM_Bhutan_2025.tif"
+    style_file: "DEM.qml"
+    output_file: "../data/processed/Health/Bhutan/Rasters/Bhutan_DEM.tif"
+    layer_name: "Bhutan_DEM"
+    max_zoom: 11
+
+  bhutan_population_raster:
+    base_path: "../data/raw/Health/Bhutan/Visuals/Step 3"
+    input_file: "BhutanPop2025_10m_Raster.tif"
+    style_file: "Population_raster_10m res.qml"
+    output_file: "../data/processed/Health/Bhutan/Rasters/Bhutan_PopulationRaster.tif"
+    layer_name: "Bhutan_PopulationRaster"
+    max_zoom: 11
+
+  bhutan_landuse:
+    base_path: "../data/raw/Health/Bhutan/Visuals/Step 3"
+    input_file: "GDA-Public-Health_Landuse_Bhutan_2025.tif"
+    style_file: "Landuse.qml"
+    output_file: "../data/processed/Health/Bhutan/Rasters/Bhutan_Landuse.tif"
+    layer_name: "Bhutan_Landuse"
+    max_zoom: 11
+
+  bhutan_pop_access_all_hf:
+    base_path: "../data/raw/Health/Bhutan/Visuals/Step 4"
+    input_file: "GDA-Public-Health_PopAccessClasses_All_HF_Bhutan_2025.tif"
+    style_file: "Pop_Accessibility_Classes.qml"
+    output_file: "../data/processed/Health/Bhutan/Rasters/Bhutan_PopAccess_AllHF.tif"
+    layer_name: "Bhutan_PopAccess_AllHF"
+    max_zoom: 13
+
+  bhutan_pop_access_hospitals:
+    base_path: "../data/raw/Health/Bhutan/Visuals/Step 4"
+    input_file: "GDA-Public-Health_PopAccessClasses_Hospitals_Bhutan_2025.tif"
+    style_file: "Pop_Accessibility_Classes.qml"
+    output_file: "../data/processed/Health/Bhutan/Rasters/Bhutan_PopAccess_Hospitals.tif"
+    layer_name: "Bhutan_PopAccess_Hospitals"
+    max_zoom: 13

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -417,3 +417,39 @@ layers:
     min_zoom: 3
     max_zoom: 9
 
+  # Bhutan - Health
+  bhutan_population_density:
+    input_file: "../data/raw/Health/Bhutan/Visuals/Step 1/GDA-Public-Health_PopulationDensity_Bhutan_2025.gpkg"
+    output_file: "../data/processed/Health/Bhutan/Vectors/PopulationDensity.mbtiles"
+    layer_name: "Bhutan_PopulationDensity"
+    min_zoom: 3
+    max_zoom: 9
+
+  bhutan_road_network:
+    input_file: "../data/raw/Health/Bhutan/Visuals/Step 2/Road_network.gpkg"
+    output_file: "../data/processed/Health/Bhutan/Vectors/RoadNetwork.mbtiles"
+    layer_name: "Bhutan_RoadNetwork"
+    min_zoom: 3
+    max_zoom: 9
+
+  bhutan_health_facilities:
+    input_file: "../data/raw/Health/Bhutan/Visuals/Step 2/Health_Facilities.gpkg"
+    output_file: "../data/processed/Health/Bhutan/Vectors/HealthFacilities.mbtiles"
+    layer_name: "Bhutan_HealthFacilities"
+    min_zoom: 3
+    max_zoom: 9
+
+  bhutan_least_access_districts:
+    input_file: "../data/raw/Health/Bhutan/Visuals/Step 5/GDA-Public-Health_Least Acess_Districts.gpkg"
+    output_file: "../data/processed/Health/Bhutan/Vectors/LeastAccessDistricts.mbtiles"
+    layer_name: "Bhutan_LeastAccessDistricts"
+    min_zoom: 3
+    max_zoom: 9
+
+  bhutan_least_access_gewogs:
+    input_file: "../data/raw/Health/Bhutan/Visuals/Step 5/GDA-Public-Health_Least Acess_Gewogs.gpkg"
+    output_file: "../data/processed/Health/Bhutan/Vectors/LeastAccessGewogs.mbtiles"
+    layer_name: "Bhutan_LeastAccessGewogs"
+    min_zoom: 3
+    max_zoom: 9
+


### PR DESCRIPTION
Add 5 raster layers (DEM, population, landuse, pop access classes) and 5 vector layers (population density, road network, health facilities, least access districts/gewogs) for Bhutan public health story.

Includes preprocessing in vector notebook to split multi-layer gpkg into separate road network and health facilities files. Also ensures processors create output directories automatically.