### PR TITLE
data: FIRAT land cover update and vegetation productivity layer

### DIFF
--- a/data-processing/notebooks/01_raster_layers.ipynb
+++ b/data-processing/notebooks/01_raster_layers.ipynb
@@ -351,6 +351,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "#### Turkey FIRAT - Vegetation Productivity Changes",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Resample from ~30m Landsat resolution to ~210m.\n# Tiles exceed Mapbox 500KB limit at z9 with scale_factor=5.\n# scale_factor=7 balances resolution vs tile size at z10.\n# Categorical data (3-class) — use mode resampling to preserve classes and avoid gaps.\nfrom rasterio.enums import Resampling\n\ninput_file = Path(\n    \"../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator/\"\n    \"masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235.tif\"\n)\noutput_file = Path(\n    \"../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator/\"\n    \"masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235_resampled.tif\"\n)\n\nresample_raster(input_file, output_file, scale_factor=7, resampling_method=Resampling.mode)\nprint(f\"Resampled → {output_file}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "new-section-header",
    "metadata": {},
    "source": [
@@ -373,7 +385,7 @@
    "id": "new-working-cell",
    "metadata": {},
    "outputs": [],
-   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_raster_layers(\n    config_path=config_path,\n    layer_keys=[\"your_layer_key_here\"],\n    upload_layer_keys=[],\n)"
+   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_raster_layers(\n    config_path=config_path,\n    layer_keys=[\"your_layer_key_here\"],\n    upload_override=True,\n)"
   }
  ],
  "metadata": {

--- a/data-processing/src/raster_config.yaml
+++ b/data-processing/src/raster_config.yaml
@@ -635,12 +635,20 @@ layers:
     layer_name: "FIRAT_land_productivity"
     max_zoom: 10
 
-  firat_land_cover_change:
+  firat_land_cover_change2:
     base_path: "../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator"
-    input_file: "land_cover_change.tif"
+    input_file: "masked_GDACR_Land-Cover-Subindicator_Turkey_2008-2023_20241108100235_v2.tif"
     style_file: "SDG_3_classes.qml"
-    output_file: "../data/processed/Climate_resilience/Turkey/Rasters/land_cover_change.tif"
-    layer_name: "FIRAT_land_cover_change"
+    output_file: "../data/processed/Climate_resilience/Turkey/Rasters/land_cover_change2.tif"
+    layer_name: "FIRAT_land_cover_change2"
+    max_zoom: 10
+
+  firat_vegetation_productivity:
+    base_path: "../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator"
+    input_file: "masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235_resampled.tif"
+    style_file: "SDG_3_classes.qml"
+    output_file: "../data/processed/Climate_resilience/Turkey/Rasters/vegetation_productivity.tif"
+    layer_name: "FIRAT_vegetation_productivity"
     max_zoom: 10
 
   firat_soc:


### PR DESCRIPTION
## Summary
- Updated FIRAT land cover layer to use masked v2 raster (`masked_GDACR_Land-Cover-Subindicator_Turkey_2008-2023_20241108100235_v2`)
- Added new vegetation productivity changes layer (`masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2`) with resampling preprocessing (scale_factor=7, mode) to stay within Mapbox 500KB tile limit

## Test plan
- [x] Both layers processed and uploaded to Mapbox successfully