### PR TITLE
data: replace Sudan crop types with crop extent and add buffer

### DIFF
--- a/data-processing/src/animated_config.yaml
+++ b/data-processing/src/animated_config.yaml
@@ -459,23 +459,18 @@ layers:
       transparent_values: [0]
 
   # Sudan - FCS
-  sudan_croptypes:
-    input_folder: "../data/raw/FCS/Sudan/Crop type maps/"
-    output_folder: "../data/processed/FCS/Sudan/APNGs/"
+  sudan_crop_extent:
+    input_folder: "../data/raw/FCS/Sudan/to_vizz/"
+    output_folder: "../data/processed/FCS/Sudan/APNGs/CropExtent/"
     min_z: 7
     max_z: 10
     vmin: 0
-    vmax: 255
+    vmax: 1
     date_format: "YYYY"
-    upload: false
     colormap:
-      type: categorical
-      values:
-        0: "#ff00ff"
-        1: "#2e41a0"
-        2: "#006724"
-        3: "#f2d33a"
-        4: "#e96a1f"
+      type: single
+      color: [255, 170, 0, 170]
+      transparent_values: [0]
 
    # Rwanda-Uganda - Agriculture
   uganda_dry_matter_productivity:

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -358,6 +358,13 @@ layers:
     min_zoom: 8
     max_zoom: 12
 
+  sudan_livestock_zone_buffer:
+    input_file: "../data/raw/FCS/Sudan/to_vizz/livestock_zone_buffer.shp"
+    output_file: "../data/processed/FCS/Sudan/Vectors/Livestock_zone_buffer.mbtiles"
+    layer_name: "Sudan_Livestock_Zone_Buffer"
+    min_zoom: 8
+    max_zoom: 12
+
   # Afghanistan - CR
   afghanistan_provinces:
     input_file: "../data/raw/Climate_resilience/Afghanistan/Datasets/Afghanistan_Provinces/AFG_Provinces_4326.shp"


### PR DESCRIPTION
Replace sudan_croptypes animated layer with sudan_crop_extent using single-color colormap (#ffaa00 at 66% opacity). Add livestock_zone_buffer vector layer config for Sudan FCS.