### PR TITLE
data: add Yemen and Nigeria health layer configs

### DIFF
--- a/data-processing/notebooks/01_raster_layers.ipynb
+++ b/data-processing/notebooks/01_raster_layers.ipynb
@@ -6,9 +6,7 @@
    "metadata": {},
    "source": [
     "# Create raster layers"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -21,9 +19,7 @@
     "This notebook documents only layers that needed **custom preprocessing** before running the standard processor — merging tiles, resampling, clipping to boundaries, assigning a missing CRS, etc. These steps are kept for reproducibility and reference.\n",
     "\n",
     "To process layers that require no preprocessing, use the **working cell** at the bottom of this notebook."
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -33,9 +29,7 @@
     "## Setup\n",
     "\n",
     "### Library import"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -50,6 +44,7 @@
     "import geopandas as gpd\n",
     "import rasterio as rio\n",
     "from rasterio.mask import mask\n",
+    "from shapely.geometry import box, mapping\n",
     "\n",
     "sys.path.append(\"../src\")\n",
     "\n",
@@ -66,9 +61,7 @@
    "metadata": {},
    "source": [
     "## Preprocessing records"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -76,9 +69,7 @@
    "metadata": {},
    "source": [
     "#### Somalia - Water"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -164,33 +155,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-43",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_raster_layers(\n",
-    "    config_path=config_path,\n",
-    "    layer_keys=[\n",
-    "        \"somalia_worldcover\",\n",
-    "        \"somalia_groundwater_storage\",\n",
-    "    ],\n",
-    "    dry_run=False,\n",
-    "    isolate_process=True,\n",
-    "    upload_layer_keys=[],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-44",
    "metadata": {},
    "source": [
     "#### West Africa - Water"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -251,30 +221,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-47",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_raster_layers(\n",
-    "    config_path=config_path,\n",
-    "    layer_keys=[\n",
-    "        \"west_africa_precipitation\",\n",
-    "        \"west_africa_groundwater_availability\",\n",
-    "    ],\n",
-    "    upload_layer_keys=[],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Mozambique - Climate Resilience (AGB)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -323,47 +274,139 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### India - Agriculture (WorldCover)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "process_raster_layers(\n",
-    "    config_path=config_path,\n",
-    "    layer_keys=[\n",
-    "        \"mozambique_agb_prediction\"\n",
-    "    ],\n",
-    "    upload_override=True,\n",
-    ")"
+    "# Resample WorldCover tile from 10m to ~100m (36000x36000 → 3600x3600).\n",
+    "# 5x was still too dense — styled RGBA tiles exceed Mapbox 500KB limit at z8.\n",
+    "# Categorical data — use nearest resampling to preserve land cover classes.\n",
+    "from rasterio.enums import Resampling\n",
+    "\n",
+    "input_file = Path(\n",
+    "    \"../data/raw/Agriculture/India/GDA-AGRI_UC1-India/ESA_WORLDCOVER/\"\n",
+    "    \"ESA_WorldCover_10m_2021_v200_N30E075_Map/ESA_WorldCover_10m_2021_v200_N30E075_Map.tif\"\n",
+    ")\n",
+    "output_file = Path(\n",
+    "    \"../data/raw/Agriculture/India/GDA-AGRI_UC1-India/ESA_WORLDCOVER/\"\n",
+    "    \"ESA_WorldCover_10m_2021_v200_N30E075_Map/ESA_WorldCover_10m_2021_v200_N30E075_Map_resampled.tif\"\n",
+    ")\n",
+    "\n",
+    "resample_raster(input_file, output_file, scale_factor=10, resampling_method=Resampling.nearest)\n",
+    "print(f\"Resampled → {output_file}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "source": "#### India - Agriculture (WorldCover)",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "#### Turkey FIRAT - Vegetation Productivity Changes"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Resample WorldCover tile from 10m to ~100m (36000x36000 → 3600x3600).\n# 5x was still too dense — styled RGBA tiles exceed Mapbox 500KB limit at z8.\n# Categorical data — use nearest resampling to preserve land cover classes.\nfrom rasterio.enums import Resampling\n\ninput_file = Path(\n    \"../data/raw/Agriculture/India/GDA-AGRI_UC1-India/ESA_WORLDCOVER/\"\n    \"ESA_WorldCover_10m_2021_v200_N30E075_Map/ESA_WorldCover_10m_2021_v200_N30E075_Map.tif\"\n)\noutput_file = Path(\n    \"../data/raw/Agriculture/India/GDA-AGRI_UC1-India/ESA_WORLDCOVER/\"\n    \"ESA_WorldCover_10m_2021_v200_N30E075_Map/ESA_WorldCover_10m_2021_v200_N30E075_Map_resampled.tif\"\n)\n\nresample_raster(input_file, output_file, scale_factor=10, resampling_method=Resampling.nearest)\nprint(f\"Resampled → {output_file}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resample from ~30m Landsat resolution to ~210m.\n",
+    "# Tiles exceed Mapbox 500KB limit at z9 with scale_factor=5.\n",
+    "# scale_factor=7 balances resolution vs tile size at z10.\n",
+    "# Categorical data (3-class) — use mode resampling to preserve classes and avoid gaps.\n",
+    "from rasterio.enums import Resampling\n",
+    "\n",
+    "input_file = Path(\n",
+    "    \"../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator/\"\n",
+    "    \"masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235.tif\"\n",
+    ")\n",
+    "output_file = Path(\n",
+    "    \"../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator/\"\n",
+    "    \"masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235_resampled.tif\"\n",
+    ")\n",
+    "\n",
+    "resample_raster(input_file, output_file, scale_factor=7, resampling_method=Resampling.mode)\n",
+    "print(f\"Resampled → {output_file}\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": "#### Turkey FIRAT - Vegetation Productivity Changes",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "#### Yemen - Health (Precipitation)"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Resample from ~30m Landsat resolution to ~210m.\n# Tiles exceed Mapbox 500KB limit at z9 with scale_factor=5.\n# scale_factor=7 balances resolution vs tile size at z10.\n# Categorical data (3-class) — use mode resampling to preserve classes and avoid gaps.\nfrom rasterio.enums import Resampling\n\ninput_file = Path(\n    \"../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator/\"\n    \"masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235.tif\"\n)\noutput_file = Path(\n    \"../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator/\"\n    \"masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235_resampled.tif\"\n)\n\nresample_raster(input_file, output_file, scale_factor=7, resampling_method=Resampling.mode)\nprint(f\"Resampled → {output_file}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assign CRS to raster (no reprojection needed)\n",
+    "input_file = \"../data/raw/Health/Yemen/Precipitaion/CHIRPS_multi_anual_mean_Yemen.tif\"\n",
+    "output_file = \"../data/raw/Health/Yemen/Precipitaion/CHIRPS_multi_anual_mean_Yemen_prj.tif\"\n",
+    "\n",
+    "with rio.open(input_file) as src:\n",
+    "    print(f\"Original CRS: {src.crs}\")\n",
+    "    print(f\"Bounds: {src.bounds}\")\n",
+    "\n",
+    "    kwargs = src.meta.copy()\n",
+    "    kwargs.update({\n",
+    "        'crs': 'EPSG:4326',\n",
+    "        'compress': 'LZW',\n",
+    "        'tiled': True,\n",
+    "        'blockxsize': 256,\n",
+    "        'blockysize': 256\n",
+    "    })\n",
+    "\n",
+    "    with rio.open(output_file, 'w', **kwargs) as dst:\n",
+    "        dst.write(src.read())\n",
+    "    print(f\"CRS assigned and saved to: {output_file}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "new-section-header",
+   "metadata": {},
+   "source": [
+    "#### Nigeria - Health (Yield Estimation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Step 4: Clip yield estimation raster with BBOX (both in EPSG:3857)\n",
+    "bbox_3857 = (932075.8830324067, 1314138.5099005199, 948109.6330324076, 1324086.8432338538)\n",
+    "bbox_geom = box(*bbox_3857)\n",
+    "\n",
+    "input_file = \"../data/raw/Health/Nigeria/Step 4/s2-cli_Yield-Total_20230101-20231231_rice.tif\"\n",
+    "output_file = \"../data/raw/Health/Nigeria/Step 4/yield_estimation_clipped.tif\"\n",
+    "\n",
+    "with rio.open(input_file) as src:\n",
+    "    out_image, out_transform = mask(src, [mapping(bbox_geom)], crop=True, nodata=src.nodata)\n",
+    "    out_meta = src.meta.copy()\n",
+    "    out_meta.update({\n",
+    "        \"height\": out_image.shape[1],\n",
+    "        \"width\": out_image.shape[2],\n",
+    "        \"transform\": out_transform,\n",
+    "    })\n",
+    "    with rio.open(output_file, \"w\", **out_meta) as dst:\n",
+    "        dst.write(out_image)\n",
+    "    print(f\"Clipped raster: {out_image.shape[2]}x{out_image.shape[1]} pixels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Process new layers\n",
@@ -375,9 +418,7 @@
     "2. Edit `layer_keys` below and run\n",
     "3. If preprocessing was needed, move those cells to the **Preprocessing records** section above with a markdown header explaining what was done\n",
     "4. Revert this cell before committing — do not accumulate processed layer keys here"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",

--- a/data-processing/notebooks/02_vector_layers.ipynb
+++ b/data-processing/notebooks/02_vector_layers.ipynb
@@ -35,15 +35,7 @@
    "id": "cell-2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import json\n",
-    "import sys\n",
-    "\n",
-    "import geopandas as gpd\n",
-    "\n",
-    "sys.path.append(\"../src\")\n",
-    "from data_processing.process_layers import process_vector_layers"
-   ]
+   "source": "import json\nimport sys\nfrom pathlib import Path\n\nimport geopandas as gpd\nimport pandas as pd\nfrom shapely.geometry import box\n\nsys.path.append(\"../src\")\nfrom data_processing.process_layers import process_vector_layers"
   },
   {
    "cell_type": "markdown",
@@ -84,22 +76,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-24",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_vector_layers(\n",
-    "    config_path=\"../src/vector_config.yaml\",\n",
-    "    layer_keys=[\n",
-    "        \"zambezi_kafue_river_transect\"\n",
-    "    ],\n",
-    "    upload_override=False,\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "source": "#### Bhutan - Health\n\nThe gpkg `GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg` contains two layers (\"Road network\" and \"Health Faciltiies\") that need to be extracted into separate files before processing.",
    "metadata": {},
@@ -109,6 +85,25 @@
   {
    "cell_type": "code",
    "source": "gpkg_path = \"../data/raw/Health/Bhutan/Visuals/Step 2/GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg\"\noutput_dir = \"../data/raw/Health/Bhutan/Visuals/Step 2\"\n\nroads = gpd.read_file(gpkg_path, layer=\"Road network\")\nroads.to_file(f\"{output_dir}/Road_network.gpkg\", driver=\"GPKG\")\n\nfacilities = gpd.read_file(gpkg_path, layer=\"Health Faciltiies\")\nfacilities.to_file(f\"{output_dir}/Health_Facilities.gpkg\", driver=\"GPKG\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "#### Nigeria - Health",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Step 2: Merge Kano and Kaduna state boundaries into a single layer\nkano = gpd.read_file(\"../data/raw/Health/Nigeria/Step 2/kano_state.gpkg\")\nkaduna = gpd.read_file(\"../data/raw/Health/Nigeria/Step 2/kaduna_state.gpkg\")\n\nmerged = pd.concat([kano, kaduna], ignore_index=True)\nmerged = gpd.GeoDataFrame(merged, geometry=\"geometry\", crs=kano.crs)\nmerged.to_file(\"../data/raw/Health/Nigeria/Step 2/kano_kaduna_states.gpkg\", driver=\"GPKG\")\nprint(f\"Merged {len(merged)} features: {merged['ADM1_EN'].tolist()}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Step 3: Clip crop type map with BBOX (both in EPSG:3857)\nbbox_3857 = (932075.8830324067, 1314138.5099005199, 948109.6330324076, 1324086.8432338538)\nbbox_geom = box(*bbox_3857)\n\ngdf = gpd.read_file(\n    \"../data/raw/Health/Nigeria/Step 3/gda-health_nigeria-kano_croptypemap-rice_bu30m.gpkg\"\n)\nclipped = gpd.clip(gdf, bbox_geom)\nclipped.to_file(\n    \"../data/raw/Health/Nigeria/Step 3/croptypemap_rice_clipped.gpkg\", driver=\"GPKG\"\n)\nprint(f\"Clipped to {len(clipped)} features\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/data-processing/notebooks/03_animated_layers.ipynb
+++ b/data-processing/notebooks/03_animated_layers.ipynb
@@ -10,8 +10,16 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## About this notebook\n\nThe source of truth for all animated layer definitions is `animated_config.yaml`. Most layers run straight from config with no manual steps required and are not documented here.\n\nThis notebook documents only layers that needed **custom preprocessing** before running the standard processor — vector-to-raster conversion, masking zero or nodata values, reprojection, clipping to boundaries, renaming files, etc. These steps are kept for reproducibility and reference.\n\nTo process layers that require no preprocessing, use the **working cell** at the bottom of this notebook.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## About this notebook\n",
+    "\n",
+    "The source of truth for all animated layer definitions is `animated_config.yaml`. Most layers run straight from config with no manual steps required and are not documented here.\n",
+    "\n",
+    "This notebook documents only layers that needed **custom preprocessing** before running the standard processor — vector-to-raster conversion, masking zero or nodata values, reprojection, clipping to boundaries, renaming files, etc. These steps are kept for reproducibility and reference.\n",
+    "\n",
+    "To process layers that require no preprocessing, use the **working cell** at the bottom of this notebook."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -63,7 +71,9 @@
    "cell_type": "markdown",
    "id": "cell-3",
    "metadata": {},
-   "source": "## Preprocessing records"
+   "source": [
+    "## Preprocessing records"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -90,22 +100,6 @@
     "    output_folder=\"../data/raw/Marine/Maldives/Rasters/Seafloor/\",\n",
     "    field_name=\"Code\",\n",
     "    reference_raster=\"../data/raw/Marine/Maldives/Rasters/Bathymetry/UC08-SDB_GulhiMaafushi_2022.tif\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-13",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\n",
-    "        \"maldives_bathymetry\",\n",
-    "        \"maldives_seafloor_classification\",\n",
-    "    ],\n",
     ")"
    ]
   },
@@ -148,23 +142,6 @@
     "        dst.write(data_to_write, 1)\n",
     "\n",
     "print(f\"Masked {len(raster_files)} phytoplankton rasters\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Tunisia - Marine: create tiles from YAML\n",
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\n",
-    "        \"tunisia_phytoplankton\",\n",
-    "        \"tunisia_seagrass\",\n",
-    "    ],\n",
-    ")"
    ]
   },
   {
@@ -231,19 +208,6 @@
     "        dst.write(data_masked, 1)\n",
     "\n",
     "print(\"Masked rasters ready:\", list(masked_rasters.keys()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"sarajevo_cams_no2_1km\"],\n",
-    ")"
    ]
   },
   {
@@ -322,19 +286,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-25",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"mongolia_pasture_biomass\"],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-28",
    "metadata": {},
@@ -390,19 +341,6 @@
     "        dst.write(data_to_write, 1)\n",
     "\n",
     "print(\"Masked rasters saved:\", list(masked_rasters.keys()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-30",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"timor_leste_water_seasonality\"],\n",
-    ")"
    ]
   },
   {
@@ -468,22 +406,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-32",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\n",
-    "        \"timor_leste_water_min_extent\",\n",
-    "        \"timor_leste_water_max_extent\",\n",
-    "    ],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-33",
    "metadata": {},
@@ -509,19 +431,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-35",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"west_africa_groundwater_anomalies\"],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-38",
    "metadata": {},
@@ -544,19 +453,6 @@
     "# clip rasters by vector\n",
     "clipped_folder = Path(\"../data/raw/Water/Pakistan/Rasters/drought_clipped/\")\n",
     "clip_rasters_by_vector(input_folder, vector_file, clipped_folder)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-41",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"pakistan_balochistan_drought\"],\n",
-    ")"
    ]
   },
   {
@@ -597,19 +493,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"mexico_nmdi\"],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-55",
    "metadata": {},
@@ -633,21 +516,41 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Yemen - Health"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-57",
+   "id": "new-section-header",
    "metadata": {},
    "outputs": [],
    "source": [
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"sudan_croptypes\"],\n",
-    ")"
+    "# Copy GGDI and Groundwater Storage Anomalies files, stripping the trailing\n",
+    "# 8-digit date suffix (e.g. _05092025) so the processor picks up the 4-digit\n",
+    "# year (e.g. _2003) as the date.\n",
+    "import shutil\n",
+    "\n",
+    "folders = {\n",
+    "    Path(\"../data/raw/Health/Yemen/GGDI/\"): Path(\"../data/raw/Health/Yemen/GGDI/renamed/\"),\n",
+    "    Path(\"../data/raw/Health/Yemen/Groundwater Storage Anomalies/\"): Path(\"../data/raw/Health/Yemen/Groundwater Storage Anomalies/renamed/\"),\n",
+    "}\n",
+    "\n",
+    "for input_folder, output_folder in folders.items():\n",
+    "    output_folder.mkdir(parents=True, exist_ok=True)\n",
+    "    for tif in sorted(input_folder.glob(\"*.tif\")):\n",
+    "        # Strip trailing _DDMMYYYY from stem (8 digits before .tif)\n",
+    "        new_name = re.sub(r\"_\\d{8}\\.tif$\", \".tif\", tif.name)\n",
+    "        shutil.copy2(tif, output_folder / new_name)\n",
+    "        print(f\"  {tif.name} → {new_name}\")\n",
+    "    print()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "new-section-header",
    "metadata": {},
    "source": [
     "## Process new layers\n",
@@ -667,13 +570,7 @@
    "id": "new-working-cell",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# WORKING CELL — edit layer_ids, run, then revert. Do not commit with real values.\n",
-    "process_animated_layers(\n",
-    "    \"../src/animated_config.yaml\",\n",
-    "    layer_ids=[\"your_layer_id_here\"],\n",
-    ")"
-   ]
+   "source": "# WORKING CELL — edit layer_ids, run, then revert. Do not commit with real values.\nprocess_animated_layers(\n    \"../src/animated_config.yaml\",\n    layer_ids=[\"your_layer_id_here\"],\n)"
   },
   {
    "cell_type": "markdown",
@@ -712,8 +609,8 @@
     "\n",
     "\n",
     "# Upload from local to S3\n",
-    "local_folder = \"../data/processed/FCS/Sudan/APNGs/\"\n",
-    "s3_folder = \"s3://esa-dev-public/APNGs/SudanCrops/\"\n",
+    "local_folder = \"../data/processed/Health/Yemen/APNGs/GroundwaterStorageAnomalies/\"\n",
+    "s3_folder = \"s3://esa-dev-public/APNGs/Yemen_GroundwaterStorageAnomalies/\"\n",
     "\n",
     "subprocess.run([\"aws\", \"s3\", \"cp\", local_folder, s3_folder, \"--recursive\"])"
    ]

--- a/data-processing/src/animated_config.yaml
+++ b/data-processing/src/animated_config.yaml
@@ -509,3 +509,34 @@ layers:
         150: "#3399ff"
         200: "#000099"
 
+  # Yemen - Health
+  yemen_ggdi:
+    input_folder: "../data/raw/Health/Yemen/GGDI/renamed/"
+    output_folder: "../data/processed/Health/Yemen/APNGs/GGDI/"
+    min_z: 3
+    max_z: 8
+    vmin: 0
+    vmax: 255
+    date_format: "YYYY"
+    colormap:
+      type: categorical
+      values:
+        1: "#fbedde"
+        2: "#fa8d57"
+        3: "#e34932"
+        4: "#95160a"
+      transparent_values: [99]
+
+  yemen_groundwater_storage_anomalies:
+    input_folder: "../data/raw/Health/Yemen/Groundwater Storage Anomalies/renamed/"
+    output_folder: "../data/processed/Health/Yemen/APNGs/GroundwaterStorageAnomalies/"
+    min_z: 3
+    max_z: 8
+    vmin: -120
+    vmax: 120
+    date_format: "YYYY"
+    colormap:
+      type: linear
+      colors: ["#ca0020", "#f4a582", "#f7f7f7", "#0571b0", "#92c5de"]
+      reserve_zero_transparent: true
+

--- a/data-processing/src/data_processing/animated_tiles.py
+++ b/data-processing/src/data_processing/animated_tiles.py
@@ -2,10 +2,8 @@
 Module for creating animated tiles
 """
 
-import glob
 import io
 import os
-import re
 import shutil
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -286,6 +284,9 @@ class RasterioEngine(TileEngine):
                     with open_raster_in_4326(self.tif_file_path) as src:
                         # Get the bounding box
                         bbox = list(src.bounds)
+                        # Normalize inverted lat bounds (positive y-res rasters)
+                        if bbox[1] > bbox[3]:
+                            bbox[1], bbox[3] = bbox[3], bbox[1]
                         # Get the count of bands
                         self.num_bands = src.count
 

--- a/data-processing/src/raster_config.yaml
+++ b/data-processing/src/raster_config.yaml
@@ -870,3 +870,21 @@ layers:
     output_file: "../data/processed/Clean_energy/Bangladesh/Rasters/LandslideHazard.tif"
     layer_name: "Bangladesh_LandslideHazard"
     max_zoom: 11
+
+  # Yemen - Health
+  yemen_precipitation:
+    base_path: "../data/raw/Health/Yemen/Precipitaion"
+    input_file: "CHIRPS_multi_anual_mean_Yemen_prj.tif"
+    style_file: "precipitation.qml"
+    output_file: "../data/processed/Health/Yemen/Rasters/Precipitation.tif"
+    layer_name: "Yemen_Precipitation"
+    max_zoom: 11
+
+  # Nigeria - Health
+  nigeria_yield_estimation:
+    base_path: "../data/raw/Health/Nigeria/Step 4"
+    input_file: "yield_estimation_clipped.tif"
+    style_file: "yieldestimation.qml"
+    output_file: "../data/processed/Health/Nigeria/Rasters/YieldEstimation.tif"
+    layer_name: "Nigeria_YieldEstimation"
+    max_zoom: 14

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -528,3 +528,18 @@ layers:
     min_zoom: 6
     max_zoom: 14
 
+  # Nigeria - Health
+  nigeria_kano_kaduna_states:
+    input_file: "../data/raw/Health/Nigeria/Step 2/kano_kaduna_states.gpkg"
+    output_file: "../data/processed/Health/Nigeria/Vectors/KanoKadunaStates.mbtiles"
+    layer_name: "Kano_Kaduna_States"
+    min_zoom: 6
+    max_zoom: 14
+
+  nigeria_croptypemap_rice:
+    input_file: "../data/raw/Health/Nigeria/Step 3/croptypemap_rice_clipped.gpkg"
+    output_file: "../data/processed/Health/Nigeria/Vectors/CroptypeMapRice.mbtiles"
+    layer_name: "Nigeria_CroptypeMapRice"
+    min_zoom: 6
+    max_zoom: 14
+


### PR DESCRIPTION
Yemen (3 layers):
- Precipitation raster (Mapbox) — config + QML style
- GGDI animated (S3) — categorical colormap with nodata=99 transparency
- Groundwater Storage Anomalies animated (S3) — linear colormap with reserve_zero_transparent to handle NaN→0 cast

Nigeria (3 layers):
- Kano/Kaduna States vector (Mapbox) — merge two state GPKGs preprocessing
- Crop Type Map Rice vector (Mapbox) — BBOX clip preprocessing + QML style
- Yield Estimation raster (Mapbox) — BBOX clip preprocessing + QML style

Bug fix:
- Fix inverted lat bounds in animated_tiles.py causing tiles to only generate for low zooms (mercantile.tiles returns empty for south > north)