### PR TITLE
data: add Madagascar, Armenia, and Afghanistan CE layer configs

### DIFF
--- a/data-processing/notebooks/01_raster_layers.ipynb
+++ b/data-processing/notebooks/01_raster_layers.ipynb
@@ -37,23 +37,7 @@
    "id": "cell-2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import geopandas as gpd\n",
-    "import rasterio as rio\n",
-    "from rasterio.mask import mask\n",
-    "from shapely.geometry import box, mapping\n",
-    "\n",
-    "sys.path.append(\"../src\")\n",
-    "\n",
-    "from data_processing.process_layers import process_prestyled_raster, process_raster_layers\n",
-    "from data_processing.utils import clip_rasters_by_vector, merge_tifs, resample_raster\n",
-    "\n",
-    "project_root = Path(\"/Users/sofia/Documents/Repos/esa/data-processing\")\n",
-    "config_path = str(project_root / \"src\" / \"raster_config.yaml\")"
-   ]
+   "source": "import sys\nfrom pathlib import Path\n\nimport geopandas as gpd\nimport rasterio as rio\nfrom rasterio.mask import mask\nfrom shapely.geometry import box, mapping\n\nsys.path.append(\"../src\")\n\nfrom data_processing.process_layers import process_prestyled_raster, process_raster_layers\nfrom data_processing.utils import clip_rasters_by_vector, merge_tifs, resample_raster\n\nproject_root = Path(\"/Users/sofia/Documents/Repos/esa/data-processing\")\nconfig_path = str(project_root / \"src\" / \"raster_config.yaml\")"
   },
   {
    "cell_type": "markdown",
@@ -422,11 +406,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "new-working-cell",
+   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_raster_layers(\n    config_path=config_path,\n    layer_keys=[\"your_layer_key_here\"],\n    upload_override=True,\n)",
    "metadata": {},
-   "outputs": [],
-   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_raster_layers(\n    config_path=config_path,\n    layer_keys=[\"your_layer_key_here\"],\n    upload_override=True,\n)"
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/data-processing/notebooks/02_vector_layers.ipynb
+++ b/data-processing/notebooks/02_vector_layers.ipynb
@@ -132,7 +132,7 @@
    "id": "new-working-cell",
    "metadata": {},
    "outputs": [],
-   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_vector_layers(\n    config_path=\"../src/vector_config.yaml\",\n    layer_keys=[\"your_layer_key_here\"],\n    upload_override=False,\n)"
+   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_vector_layers(\n    config_path=\"../src/vector_config.yaml\",\n    layer_keys=[\"your_layer_key_here\"],\n    upload_override=True,\n)"
   }
  ],
  "metadata": {

--- a/data-processing/src/animated_config.yaml
+++ b/data-processing/src/animated_config.yaml
@@ -540,3 +540,16 @@ layers:
       colors: ["#ca0020", "#f4a582", "#f7f7f7", "#0571b0", "#92c5de"]
       reserve_zero_transparent: true
 
+  # Afghanistan - CR
+  afghanistan_irrigation_channel:
+    input_folder: "../data/raw/Climate_resilience/Afghanistan/Datasets/irrigation_channel/renamed/"
+    output_folder: "../data/processed/Climate_resilience/Afghanistan/APNGs/IrrigationChannel/"
+    min_z: 10
+    max_z: 12
+    vmin: 0
+    vmax: 255
+    date_format: "YYYYMMDD"
+    colormap:
+      type: linear
+      colors: ["#000000", "#ffffff"]
+

--- a/data-processing/src/data_processing/process_layers.py
+++ b/data-processing/src/data_processing/process_layers.py
@@ -1,27 +1,31 @@
 """Process raster and vector layers based on YAML configuration."""
 
-
+import math
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
+import rasterio
 import yaml
+from rasterio.warp import transform_bounds
 
-import os
-
-from .raster_processor import RasterProcessor
-from .vector_processor import VectorProcessor
 from helpers.cog_converter import COGConverter
 from helpers.mapbox_uploader import upload_to_mapbox
 from helpers.mbtiles_converter import MBTilesConverterFactory
 
+from .raster_processor import RasterProcessor
+from .vector_processor import VectorProcessor
+
 # ── Shared helpers ────────────────────────────────────────────────────────────
 
+
 def _read_layers(config_path: str) -> dict:
-    with open(config_path, 'r') as f:
+    with open(config_path, "r") as f:
         config = yaml.safe_load(f) or {}
-    return config.get('layers', {})
+    return config.get("layers", {})
 
 
 def _resolve_upload_flag(
@@ -34,16 +38,14 @@ def _resolve_upload_flag(
         return upload_override
     if upload_layer_keys_set is not None:
         return layer_id in upload_layer_keys_set
-    return layer_config.get('upload', False)
+    return layer_config.get("upload", False)
 
 
 # ── Pre-styled raster (no QML) ───────────────────────────────────────────────
 
+
 def _native_max_zoom(file: Path) -> int:
     """Return the native max zoom of a raster based on its resolution."""
-    import math
-    import rasterio
-    from rasterio.warp import transform_bounds
     with rasterio.open(file) as src:
         bounds = transform_bounds(src.crs, "EPSG:4326", *src.bounds)
         res_x = abs(src.transform.a)
@@ -72,9 +74,6 @@ def _normalize_to_uint8(input_file: Path, output_file: Path, percentile: float =
         output_file: Destination uint8 GeoTIFF.
         percentile: Low/high percentile used for clipping (default 2 / 98).
     """
-    import numpy as np
-    import rasterio
-
     with rasterio.open(input_file) as src:
         meta = src.meta.copy()
         data = src.read()
@@ -126,7 +125,6 @@ def process_prestyled_raster(
         percentile: Percentile used for float→uint8 contrast stretch (default 2/98).
         upload: Whether to upload the MBTiles to Mapbox.
     """
-    import rasterio
 
     input_file = Path(input_file)
     output_file = Path(output_file)
@@ -143,7 +141,7 @@ def process_prestyled_raster(
     cog_input = input_file
     if needs_normalization:
         normalized_path = output_file.parent / f"normalized_{output_file.name}"
-        print(f"⚖️  Normalizing float32 → uint8 (percentile clip {percentile}/{100-percentile})")
+        print(f"⚖️  Normalizing float32 → uint8 (percentile clip {percentile}/{100 - percentile})")
         _normalize_to_uint8(input_file, normalized_path, percentile=percentile)
         cog_input = normalized_path
 
@@ -173,6 +171,7 @@ def process_prestyled_raster(
 
 # ── Raster ────────────────────────────────────────────────────────────────────
 
+
 def _process_rasters(
     config_path: str,
     layer_keys: list = None,
@@ -189,20 +188,20 @@ def _process_rasters(
     processed_count = 0
     failed_count = 0
 
-    print(f'Found {len(layers)} raster layer(s) to process\n')
+    print(f"Found {len(layers)} raster layer(s) to process\n")
 
     for layer_id, layer_config in layers.items():
         try:
-            base_path = Path(layer_config['base_path'])
-            input_file = base_path / layer_config['input_file']
-            output_file = Path(layer_config['output_file'])
+            base_path = Path(layer_config["base_path"])
+            input_file = base_path / layer_config["input_file"]
+            output_file = Path(layer_config["output_file"])
 
             style_file = None
-            if layer_config.get('style_file'):
-                style_file = base_path / layer_config['style_file']
+            if layer_config.get("style_file"):
+                style_file = base_path / layer_config["style_file"]
 
             if not input_file.exists():
-                print(f'SKIP {layer_id}: Input file not found at {input_file}')
+                print(f"SKIP {layer_id}: Input file not found at {input_file}")
                 failed_count += 1
                 continue
 
@@ -211,27 +210,28 @@ def _process_rasters(
             )
 
             vector_file = None
-            if layer_config.get('vector_file'):
-                vector_file = Path(layer_config['vector_file'])
+            if layer_config.get("vector_file"):
+                vector_file = Path(layer_config["vector_file"])
 
             RasterProcessor(
                 input_file,
                 output_file=output_file,
                 qml_file=style_file,
-                layer_name=layer_config['layer_name'],
+                layer_name=layer_config["layer_name"],
                 vector_file=vector_file,
                 upload=upload_flag,
-                max_zoom=layer_config.get('max_zoom', 11),
+                max_zoom=layer_config.get("max_zoom", 11),
+                tile_format=layer_config.get("tile_format", "PNG"),
             ).process()
 
             print(f"✅ {layer_id}: {layer_config['layer_name']} (upload={upload_flag})")
             processed_count += 1
 
         except Exception as e:
-            print(f'❌ {layer_id}: {str(e)}')
+            print(f"❌ {layer_id}: {str(e)}")
             failed_count += 1
 
-    print(f'\n📊 Summary: {processed_count} processed, {failed_count} failed')
+    print(f"\n📊 Summary: {processed_count} processed, {failed_count} failed")
     return processed_count, failed_count
 
 
@@ -295,20 +295,20 @@ sys.exit(1 if failed > 0 else 0)
     fail = 0
 
     for key in keys_to_run:
-        print(f'\n=== Processing raster {key} in isolated process ===')
+        print(f"\n=== Processing raster {key} in isolated process ===")
 
         if upload_override is not None:
-            upload_arg = '1' if upload_override else '0'
+            upload_arg = "1" if upload_override else "0"
         elif upload_layer_keys_set is not None:
-            upload_arg = '1' if key in upload_layer_keys_set else '0'
+            upload_arg = "1" if key in upload_layer_keys_set else "0"
         else:
-            upload_arg = 'none'
+            upload_arg = "none"
 
         try:
             subprocess.run(
                 [
                     sys.executable,
-                    '-c',
+                    "-c",
                     runner,
                     config_path,
                     key,
@@ -319,14 +319,15 @@ sys.exit(1 if failed > 0 else 0)
             )
             ok += 1
         except subprocess.CalledProcessError:
-            print(f'❌ {key}: failed in isolated process')
+            print(f"❌ {key}: failed in isolated process")
             fail += 1
 
-    print(f'\n📊 Isolated summary: {ok} succeeded, {fail} failed')
+    print(f"\n📊 Isolated summary: {ok} succeeded, {fail} failed")
     return ok, fail
 
 
 # ── Vector ────────────────────────────────────────────────────────────────────
+
 
 def _process_vectors(
     config_path: str,
@@ -345,15 +346,15 @@ def _process_vectors(
     processed_count = 0
     failed_count = 0
 
-    print(f'📋 Found {len(layers)} vector layer(s) to process\n')
+    print(f"📋 Found {len(layers)} vector layer(s) to process\n")
 
     for layer_id, layer_config in layers.items():
         try:
-            input_file = Path(layer_config['input_file'])
-            output_file = Path(layer_config['output_file'])
+            input_file = Path(layer_config["input_file"])
+            output_file = Path(layer_config["output_file"])
 
             if not input_file.exists():
-                print(f'⚠️  SKIP {layer_id}: Input file not found at {input_file}')
+                print(f"⚠️  SKIP {layer_id}: Input file not found at {input_file}")
                 failed_count += 1
                 continue
 
@@ -362,19 +363,16 @@ def _process_vectors(
             )
 
             if dry_run:
-                print(
-                    f"✓ DRY RUN {layer_id}: {layer_config['layer_name']} "
-                    f"(upload={upload_flag})"
-                )
+                print(f"✓ DRY RUN {layer_id}: {layer_config['layer_name']} (upload={upload_flag})")
                 processed_count += 1
                 continue
 
             VectorProcessor(
                 input_file=input_file,
                 output_file=output_file,
-                layer_name=layer_config['layer_name'],
-                min_zoom=layer_config.get('min_zoom', 0),
-                max_zoom=layer_config.get('max_zoom', 14),
+                layer_name=layer_config["layer_name"],
+                min_zoom=layer_config.get("min_zoom", 0),
+                max_zoom=layer_config.get("max_zoom", 14),
                 upload=upload_flag,
             ).process()
 
@@ -382,10 +380,10 @@ def _process_vectors(
             processed_count += 1
 
         except Exception as e:
-            print(f'❌ {layer_id}: {str(e)}')
+            print(f"❌ {layer_id}: {str(e)}")
             failed_count += 1
 
-    print(f'\n📊 Summary: {processed_count} processed, {failed_count} failed')
+    print(f"\n📊 Summary: {processed_count} processed, {failed_count} failed")
     return processed_count, failed_count
 
 
@@ -415,4 +413,3 @@ def process_vector_layers(
         upload_override=upload_override,
         upload_layer_keys=upload_layer_keys,
     )
-

--- a/data-processing/src/data_processing/raster_processor.py
+++ b/data-processing/src/data_processing/raster_processor.py
@@ -35,6 +35,7 @@ class RasterProcessor:
         create_mbtiles: bool = True,
         vector_file: Path = None,
         max_zoom: int = None,
+        tile_format: str = "PNG",
     ):
         """
         Initialize the RasterProcessor object.
@@ -48,6 +49,9 @@ class RasterProcessor:
             create_mbtiles (bool): Whether to create an MBTiles file.
             vector_file (Path): Optional path to a shapefile for clipping the raster.
             max_zoom (int): Maximum zoom level for COG conversion.
+            tile_format (str): Tile format for MBTiles ("PNG" or "JPEG").
+                               Use "JPEG" for continuous/interpolated rasters
+                               that exceed the Mapbox 500KB tile size limit.
         """
         self.input_file = input_file
         self.qml_file = qml_file
@@ -57,6 +61,7 @@ class RasterProcessor:
         self.create_mbtiles = create_mbtiles
         self.vector_file = vector_file
         self.max_zoom = max_zoom
+        self.tile_format = tile_format
         self.clipped_raster_path = None
 
     def clip_raster(self) -> Path:
@@ -219,7 +224,9 @@ class RasterProcessor:
             if self.create_mbtiles:
                 console.print("📦 Converting to MBTiles...", style="bold white")
                 mbtiles_path = geotiff_path.with_suffix(".mbtiles")
-                MBTilesConverterFactory.convert(geotiff_path, mbtiles_path)
+                MBTilesConverterFactory.convert(
+                    geotiff_path, mbtiles_path, tile_format=self.tile_format
+                )
                 console.print(
                     f"✅ Processing complete. Output saved to {mbtiles_path}", style="bold green"
                 )

--- a/data-processing/src/raster_config.yaml
+++ b/data-processing/src/raster_config.yaml
@@ -364,7 +364,7 @@ layers:
     max_zoom: 11
 
   # Somalia - Water
-  somalia_worldcover:
+  somalia_worldcover:  # preprocessing: merge + resample + clip (notebook 01)
     base_path: "../data/raw/Water/Somalia/Rasters/"
     input_file: "Clipped/WorldCover_resampled.tif"
     style_file: "WorldCover.qml"
@@ -372,7 +372,7 @@ layers:
     layer_name: "WorldCover"
     max_zoom: 11
 
-  somalia_groundwater_storage:
+  somalia_groundwater_storage:  # preprocessing: clip to Somalia (notebook 01)
     base_path: "../data/raw/Water/Somalia/Rasters/Clipped/"
     input_file: "3_GDAWater_GroundwaterResourcesEstimation_MeanAnnualGroundwaterStorageBalance_Multi-annual_Somalia_2003-2024_10042025.tif"
     style_file: "Groundwater.qml"
@@ -381,7 +381,7 @@ layers:
     max_zoom: 11
 
   # West Africa - Water
-  west_africa_precipitation:
+  west_africa_precipitation:  # preprocessing: assign CRS (notebook 01)
     base_path: "../data/raw/Water/West Africa/Rasters/"
     input_file: "1_GDAWater_Precipitation_MeanAnnualPrecipitation_Multi-annual_WestAfrica_2003-2024_23052025_prj.tif"
     style_file: "precipitation.qml"
@@ -389,7 +389,7 @@ layers:
     layer_name: "MeanAnnualPrecipitation_WestAfrica"
     max_zoom: 5
 
-  west_africa_groundwater_availability:
+  west_africa_groundwater_availability:  # preprocessing: clip to West Africa (notebook 01)
     base_path: "../data/raw/Water/West Africa/Rasters/Clipped"
     input_file: "3a_GDAWATER_Groundwater_Availability_percentage_WestAfrica_2024_03.tif"
     style_file: "Groundwater_Availability_percentage.qml"
@@ -643,7 +643,7 @@ layers:
     layer_name: "FIRAT_land_cover_change2"
     max_zoom: 10
 
-  firat_vegetation_productivity:
+  firat_vegetation_productivity:  # preprocessing: resample scale_factor=7 (notebook 01)
     base_path: "../data/raw/Climate_resilience/Turkey/FIRAT/SDG_1531_Indicator"
     input_file: "masked_GDACR_landsat_DMB_productivity-subindicator-GPGv2_Turkey_2008-2023_20241108100235_resampled.tif"
     style_file: "SDG_3_classes.qml"
@@ -695,7 +695,7 @@ layers:
     max_zoom: 13
   
 # Mozambique - CR
-  mozambique_agb_prediction:
+  mozambique_agb_prediction:  # preprocessing: extract band1 + resample (notebook 01)
     base_path: "../data/raw/Climate_resilience/Mozambique/Rasters"
     input_file: "0007MZ_GIL_L4_AGB_band1_resampled.tiff"
     style_file: "band1.qml"
@@ -772,7 +772,7 @@ layers:
     max_zoom: 13
 
   # India - Agriculture
-  india_worldcover:
+  india_worldcover:  # preprocessing: resample scale_factor=10 (notebook 01)
     base_path: "../data/raw/Agriculture/India/GDA-AGRI_UC1-India/ESA_WORLDCOVER/ESA_WorldCover_10m_2021_v200_N30E075_Map"
     input_file: "ESA_WorldCover_10m_2021_v200_N30E075_Map_resampled.tif"
     style_file: "../landcover.qml"
@@ -883,8 +883,8 @@ layers:
     base_path: "../data/raw/Clean_energy/Bangladesh_Climate/"
     input_file: "Flood_hazard_clipped.tif"
     style_file: "Flood_hazard_clipped.qml"
-    output_file: "../data/processed/Clean_energy/Bangladesh/Rasters/FloodHazardClipped.tif"
-    layer_name: "Bangladesh_FloodHazardClipped"
+    output_file: "../data/processed/Clean_energy/Bangladesh/Rasters/FloodHazardClipped2.tif"
+    layer_name: "Bangladesh_FloodHazardClipped2"
     max_zoom: 11
 
   bangladesh_landslide_hazard:
@@ -896,7 +896,7 @@ layers:
     max_zoom: 11
 
   # Yemen - Health
-  yemen_precipitation:
+  yemen_precipitation:  # preprocessing: assign CRS (notebook 01)
     base_path: "../data/raw/Health/Yemen/Precipitaion"
     input_file: "CHIRPS_multi_anual_mean_Yemen_prj.tif"
     style_file: "precipitation.qml"
@@ -905,10 +905,70 @@ layers:
     max_zoom: 11
 
   # Nigeria - Health
-  nigeria_yield_estimation:
+  nigeria_yield_estimation:  # preprocessing: clip with bbox (notebook 01)
     base_path: "../data/raw/Health/Nigeria/Step 4"
     input_file: "yield_estimation_clipped.tif"
     style_file: "yieldestimation.qml"
     output_file: "../data/processed/Health/Nigeria/Rasters/YieldEstimation.tif"
     layer_name: "Nigeria_YieldEstimation"
     max_zoom: 14
+
+  # Madagascar - CE
+  madagascar_cropland_mask:
+    base_path: "../data/raw/Clean_energy/Madagascar_demand/selectedSubset"
+    input_file: "Cropland_mask_LTF.tif"
+    style_file: "Cropland_mask_LTF.qml"
+    output_file: "../data/processed/Clean_energy/Madagascar/Rasters/CroplandMask.tif"
+    layer_name: "Madagascar_CroplandMask"
+    max_zoom: 11
+
+  madagascar_irrigation_class:
+    base_path: "../data/raw/Clean_energy/Madagascar_demand/selectedSubset"
+    input_file: "OB_irrigation_class_LTF.tif"
+    style_file: "OB_irrigation_class_LTF.qml"
+    output_file: "../data/processed/Clean_energy/Madagascar/Rasters/IrrigationClass.tif"
+    layer_name: "Madagascar_IrrigationClass"
+    max_zoom: 11
+
+  # Armenia - CE
+  armenia_lulc:
+    base_path: "../data/raw/Clean_energy/Armenia_Wind"
+    input_file: "LULC.tif"
+    style_file: "LULC_symbology.qml"
+    output_file: "../data/processed/Clean_energy/Armenia/Rasters/LULC.tif"
+    layer_name: "Armenia_LULC"
+    max_zoom: 11
+
+  armenia_wind_speed_140m:
+    base_path: "../data/raw/Clean_energy/Armenia_Wind/1_22_391_Armenien/geotiff_Dateien"
+    input_file: "ws_140m.tif"
+    style_file: "ws_140m.qml"
+    output_file: "../data/processed/Clean_energy/Armenia/Rasters/WindSpeed140m.tif"
+    layer_name: "Armenia_WindSpeed140m"
+    max_zoom: 11
+
+  armenia_power_density_100m:
+    base_path: "../data/raw/Clean_energy/Armenia_Wind/1_22_391_Armenien/geotiff_Dateien"
+    input_file: "pd_100m.tif"
+    style_file: "pd_100m.qml"
+    output_file: "../data/processed/Clean_energy/Armenia/Rasters/PowerDensity100m.tif"
+    layer_name: "Armenia_PowerDensity100m"
+    max_zoom: 11
+
+  armenia_cloud_probability:
+    base_path: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer"
+    input_file: "CloudProbability_Armenia_2022.tif"
+    style_file: "../Armenia_SymbologyLayers/CloudProbability_Armenia_2022.qml"
+    output_file: "../data/processed/Clean_energy/Armenia/Rasters/CloudProbability.tif"
+    layer_name: "Armenia_CloudProbability"
+    max_zoom: 10
+    tile_format: JPEG
+
+  armenia_solar_radiation:
+    base_path: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer"
+    input_file: "SolarRadiation_Armenia_25m.tif"
+    style_file: "../Armenia_SymbologyLayers/SolarRadiation_Armenia_25m.qml"
+    output_file: "../data/processed/Clean_energy/Armenia/Rasters/SolarRadiation.tif"
+    layer_name: "Armenia_SolarRadiation"
+    max_zoom: 10
+    tile_format: JPEG

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -432,14 +432,14 @@ layers:
     min_zoom: 3
     max_zoom: 9
 
-  bhutan_road_network:
+  bhutan_road_network:  # preprocessing: extract layer from gpkg (notebook 02)
     input_file: "../data/raw/Health/Bhutan/Visuals/Step 2/Road_network.gpkg"
     output_file: "../data/processed/Health/Bhutan/Vectors/RoadNetwork.mbtiles"
     layer_name: "Bhutan_RoadNetwork"
     min_zoom: 3
     max_zoom: 9
 
-  bhutan_health_facilities:
+  bhutan_health_facilities:  # preprocessing: extract layer from gpkg (notebook 02)
     input_file: "../data/raw/Health/Bhutan/Visuals/Step 2/Health_Facilities.gpkg"
     output_file: "../data/processed/Health/Bhutan/Vectors/HealthFacilities.mbtiles"
     layer_name: "Bhutan_HealthFacilities"
@@ -529,17 +529,61 @@ layers:
     max_zoom: 14
 
   # Nigeria - Health
-  nigeria_kano_kaduna_states:
+  nigeria_kano_kaduna_states:  # preprocessing: merge Kano + Kaduna states (notebook 02)
     input_file: "../data/raw/Health/Nigeria/Step 2/kano_kaduna_states.gpkg"
     output_file: "../data/processed/Health/Nigeria/Vectors/KanoKadunaStates.mbtiles"
     layer_name: "Kano_Kaduna_States"
     min_zoom: 6
     max_zoom: 14
 
-  nigeria_croptypemap_rice:
+  nigeria_croptypemap_rice:  # preprocessing: clip with bbox (notebook 02)
     input_file: "../data/raw/Health/Nigeria/Step 3/croptypemap_rice_clipped.gpkg"
     output_file: "../data/processed/Health/Nigeria/Vectors/CroptypeMapRice.mbtiles"
     layer_name: "Nigeria_CroptypeMapRice"
+    min_zoom: 6
+    max_zoom: 14
+
+  # Madagascar - CE
+  madagascar_buildings:
+    input_file: "../data/raw/Clean_energy/Madagascar_demand/selectedSubset/buildings_subsetClasses.json"
+    output_file: "../data/processed/Clean_energy/Madagascar/Vectors/Buildings.mbtiles"
+    layer_name: "Madagascar_Buildings"
+    min_zoom: 6
+    max_zoom: 14
+
+  madagascar_roads:
+    input_file: "../data/raw/Clean_energy/Madagascar_demand/selectedSubset/roads_subset.geojson"
+    output_file: "../data/processed/Clean_energy/Madagascar/Vectors/Roads.mbtiles"
+    layer_name: "Madagascar_Roads"
+    min_zoom: 6
+    max_zoom: 14
+
+  madagascar_settlements:
+    input_file: "../data/raw/Clean_energy/Madagascar_demand/selectedSubset/settlement_subset2.geojson"
+    output_file: "../data/processed/Clean_energy/Madagascar/Vectors/Settlements.mbtiles"
+    layer_name: "Madagascar_Settlements"
+    min_zoom: 6
+    max_zoom: 14
+
+  # Armenia - CE Solar
+  armenia_solar_building:
+    input_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/Syunik_cityLevel/Syunik_solar_Building.shp"
+    output_file: "../data/processed/Clean_energy/Armenia/Vectors/SolarBuilding.mbtiles"
+    layer_name: "Armenia_SolarBuilding"
+    min_zoom: 6
+    max_zoom: 14
+
+  armenia_edges:
+    input_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/Syunik_cityLevel/v3_edges.shp"
+    output_file: "../data/processed/Clean_energy/Armenia/Vectors/Edges.mbtiles"
+    layer_name: "Armenia_Edges"
+    min_zoom: 6
+    max_zoom: 14
+
+  armenia_solar_potential:
+    input_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/Syunik_cityLevel/v4_SolarPotential.shp"
+    output_file: "../data/processed/Clean_energy/Armenia/Vectors/SolarPotential.mbtiles"
+    layer_name: "Armenia_SolarPotential"
     min_zoom: 6
     max_zoom: 14
 


### PR DESCRIPTION
Add raster, vector configs for Clean Energy stories:
- Madagascar: cropland mask, irrigation class (raster); buildings, roads, settlements (vector)
- Armenia: LULC, wind speed, power density, cloud probability, solar radiation (raster); solar building, edges, solar potential (vector)

Also animated tiles for Climate Resilience
- Afghanistan: irrigation channel (animated)

Add JPEG tile_format option to raster pipeline for continuous rasters that exceed Mapbox's 500KB tile size limit (cloud probability, solar radiation). Passes tile_format from YAML config through process_layers to RasterProcessor to MBTilesConverterFactory.

Also: clean up imports in process_layers.py, add preprocessing comments to existing config entries.