### PR TITLE
fix: outro step redirects to globe at scroll end

### DIFF
--- a/client/src/containers/story/steps/layouts/outro-step.tsx
+++ b/client/src/containers/story/steps/layouts/outro-step.tsx
@@ -79,7 +79,11 @@ const OutroStepLayout = ({ step, showContent, disclaimer }: MediaStepLayoutProps
 
   // Sentinel at the very bottom of the outro: only enters view once the user has
   // scrolled past the outro content, so we redirect at the true end of the story.
-  const isEnd = useInView(endRef, { amount: 'some' });
+  // The outro is the last step, so the page can't scroll past the sentinel — at max
+  // scroll it sits right at (or just below) the fold and would never intersect. The
+  // bottom margin grows the observer root downward so it registers in the final
+  // stretch of scroll, while still gating the redirect on `hasSeenOutro`.
+  const isEnd = useInView(endRef, { amount: 'some', margin: '0px 0px 200px 0px' });
 
   const [show, setShow] = useState(true);
   // True once the user has scrolled far enough to see the "Continue scrolling" hint;


### PR DESCRIPTION
## Summary
Fixes the story **outro step not returning to the globe**.

The outro is the last story step, so the page can't scroll past it. With `useScroll({ offset: ['start end', 'end start'] })`, `scrollYProgress` for a last element maxes out at ~0.75, and the bottom `endRef` sentinel sat at `absolute bottom-0` — exactly at (or just below) the maximum scroll position, so it never intersected the viewport. `isEnd` never flipped true and the redirect to `/globe` (plus the story layer clear) never fired.

The fix grows the `useInView` observer root downward via `margin: '0px 0px 200px 0px'`, so the sentinel registers in the final stretch of scroll. The redirect is still gated on `hasSeenOutro` (the "Continue scrolling to explore more stories" hint, `scrollYProgress > 0.5`), so it only fires *after* that hint appears and the user keeps scrolling to the end.

## Context
The outro logic shipped in #243, but this follow-up commit landed just after that PR merged, so it needs its own PR into `develop`.

## Test plan
- [ ] Scroll to the end of a story's outro — after the "Continue scrolling to explore more stories" hint appears, continuing to scroll redirects to `/globe`.
- [ ] Story layers are cleared on redirect (globe shows no leftover story layers).
- [ ] Redirect does NOT fire mid-outro before the hint.
