### PR TITLE
data: fix Armenia CE solar layers transparency and zoom

### DIFF
--- a/data-processing/notebooks/01_raster_layers.ipynb
+++ b/data-processing/notebooks/01_raster_layers.ipynb
@@ -430,6 +430,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Armenia - CE Solar (Solar Radiation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resample SolarRadiation from 11065x10977 (25m, 468MB) to reduce tile size for PNG at zoom 9.\n",
+    "# Continuous data — use average resampling to preserve radiation values.\n",
+    "\n",
+    "raw_dir = Path(\"../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer/\")\n",
+    "input_file = raw_dir / \"SolarRadiation_Armenia_25m.tif\"\n",
+    "output_file = raw_dir / \"SolarRadiation_Armenia_25m_resampled.tif\"\n",
+    "\n",
+    "resample_raster(input_file, output_file, scale_factor=2, resampling_method=Resampling.average)\n",
+    "print(f\"Resampled → {output_file}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Process new layers\n",
     "\n",
     "Use the cell below to process layers that run straight from config (no preprocessing needed).\n",
@@ -446,7 +470,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_raster_layers(\n    config_path=config_path,\n    layer_keys=[\"\"],\n    upload_override=True,\n)"
+   "source": [
+    "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\n",
+    "process_raster_layers(\n",
+    "    config_path=config_path,\n",
+    "    layer_keys=[\"\"],\n",
+    "    upload_override=True,\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/data-processing/notebooks/02_vector_layers.ipynb
+++ b/data-processing/notebooks/02_vector_layers.ipynb
@@ -6,16 +6,20 @@
    "metadata": {},
    "source": [
     "# Create vector layers"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": "## About this notebook\n\nThe source of truth for all vector layer definitions is `vector_config.yaml`. Most layers run straight from config with no manual steps required and are not documented here.\n\nThis notebook documents only layers that needed **custom preprocessing** before running the standard processor. These steps are kept for reproducibility and reference.\n\nTo process layers that require no preprocessing, use the **working cell** at the bottom of this notebook.",
    "metadata": {},
-   "outputs": [],
-   "execution_count": null
+   "source": [
+    "## About this notebook\n",
+    "\n",
+    "The source of truth for all vector layer definitions is `vector_config.yaml`. Most layers run straight from config with no manual steps required and are not documented here.\n",
+    "\n",
+    "This notebook documents only layers that needed **custom preprocessing** before running the standard processor. These steps are kept for reproducibility and reference.\n",
+    "\n",
+    "To process layers that require no preprocessing, use the **working cell** at the bottom of this notebook."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -25,9 +29,7 @@
     "## Setup\n",
     "\n",
     "### Library import"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -35,15 +37,26 @@
    "id": "cell-2",
    "metadata": {},
    "outputs": [],
-   "source": "import json\nimport sys\nfrom pathlib import Path\n\nimport geopandas as gpd\nimport pandas as pd\nfrom shapely.geometry import box\n\nsys.path.append(\"../src\")\nfrom data_processing.process_layers import process_vector_layers"
+   "source": [
+    "import json\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "from shapely.geometry import box\n",
+    "\n",
+    "sys.path.append(\"../src\")\n",
+    "from data_processing.process_layers import process_vector_layers"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-3",
    "metadata": {},
-   "source": "## Preprocessing records",
-   "outputs": [],
-   "execution_count": null
+   "source": [
+    "## Preprocessing records"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -51,9 +64,7 @@
    "metadata": {},
    "source": [
     "#### Zambezi basin - Water"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -77,36 +88,71 @@
   },
   {
    "cell_type": "markdown",
-   "source": "#### Bhutan - Health\n\nThe gpkg `GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg` contains two layers (\"Road network\" and \"Health Faciltiies\") that need to be extracted into separate files before processing.",
    "metadata": {},
-   "outputs": [],
-   "execution_count": null
+   "source": [
+    "#### Bhutan - Health\n",
+    "\n",
+    "The gpkg `GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg` contains two layers (\"Road network\" and \"Health Faciltiies\") that need to be extracted into separate files before processing."
+   ]
   },
   {
    "cell_type": "code",
-   "source": "gpkg_path = \"../data/raw/Health/Bhutan/Visuals/Step 2/GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg\"\noutput_dir = \"../data/raw/Health/Bhutan/Visuals/Step 2\"\n\nroads = gpd.read_file(gpkg_path, layer=\"Road network\")\nroads.to_file(f\"{output_dir}/Road_network.gpkg\", driver=\"GPKG\")\n\nfacilities = gpd.read_file(gpkg_path, layer=\"Health Faciltiies\")\nfacilities.to_file(f\"{output_dir}/Health_Facilities.gpkg\", driver=\"GPKG\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gpkg_path = \"../data/raw/Health/Bhutan/Visuals/Step 2/GDA-Public-Health_RoadN_HFs_Bhutan_2025.gpkg\"\n",
+    "output_dir = \"../data/raw/Health/Bhutan/Visuals/Step 2\"\n",
+    "\n",
+    "roads = gpd.read_file(gpkg_path, layer=\"Road network\")\n",
+    "roads.to_file(f\"{output_dir}/Road_network.gpkg\", driver=\"GPKG\")\n",
+    "\n",
+    "facilities = gpd.read_file(gpkg_path, layer=\"Health Faciltiies\")\n",
+    "facilities.to_file(f\"{output_dir}/Health_Facilities.gpkg\", driver=\"GPKG\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": "#### Nigeria - Health",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "#### Nigeria - Health"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Step 2: Merge Kano and Kaduna state boundaries into a single layer\nkano = gpd.read_file(\"../data/raw/Health/Nigeria/Step 2/kano_state.gpkg\")\nkaduna = gpd.read_file(\"../data/raw/Health/Nigeria/Step 2/kaduna_state.gpkg\")\n\nmerged = pd.concat([kano, kaduna], ignore_index=True)\nmerged = gpd.GeoDataFrame(merged, geometry=\"geometry\", crs=kano.crs)\nmerged.to_file(\"../data/raw/Health/Nigeria/Step 2/kano_kaduna_states.gpkg\", driver=\"GPKG\")\nprint(f\"Merged {len(merged)} features: {merged['ADM1_EN'].tolist()}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Step 2: Merge Kano and Kaduna state boundaries into a single layer\n",
+    "kano = gpd.read_file(\"../data/raw/Health/Nigeria/Step 2/kano_state.gpkg\")\n",
+    "kaduna = gpd.read_file(\"../data/raw/Health/Nigeria/Step 2/kaduna_state.gpkg\")\n",
+    "\n",
+    "merged = pd.concat([kano, kaduna], ignore_index=True)\n",
+    "merged = gpd.GeoDataFrame(merged, geometry=\"geometry\", crs=kano.crs)\n",
+    "merged.to_file(\"../data/raw/Health/Nigeria/Step 2/kano_kaduna_states.gpkg\", driver=\"GPKG\")\n",
+    "print(f\"Merged {len(merged)} features: {merged['ADM1_EN'].tolist()}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "# Step 3: Clip crop type map with BBOX (both in EPSG:3857)\nbbox_3857 = (932075.8830324067, 1314138.5099005199, 948109.6330324076, 1324086.8432338538)\nbbox_geom = box(*bbox_3857)\n\ngdf = gpd.read_file(\n    \"../data/raw/Health/Nigeria/Step 3/gda-health_nigeria-kano_croptypemap-rice_bu30m.gpkg\"\n)\nclipped = gpd.clip(gdf, bbox_geom)\nclipped.to_file(\n    \"../data/raw/Health/Nigeria/Step 3/croptypemap_rice_clipped.gpkg\", driver=\"GPKG\"\n)\nprint(f\"Clipped to {len(clipped)} features\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Step 3: Clip crop type map with BBOX (both in EPSG:3857)\n",
+    "bbox_3857 = (932075.8830324067, 1314138.5099005199, 948109.6330324076, 1324086.8432338538)\n",
+    "bbox_geom = box(*bbox_3857)\n",
+    "\n",
+    "gdf = gpd.read_file(\n",
+    "    \"../data/raw/Health/Nigeria/Step 3/gda-health_nigeria-kano_croptypemap-rice_bu30m.gpkg\"\n",
+    ")\n",
+    "clipped = gpd.clip(gdf, bbox_geom)\n",
+    "clipped.to_file(\n",
+    "    \"../data/raw/Health/Nigeria/Step 3/croptypemap_rice_clipped.gpkg\", driver=\"GPKG\"\n",
+    ")\n",
+    "print(f\"Clipped to {len(clipped)} features\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -122,9 +168,7 @@
     "2. Edit `layer_keys` below and run\n",
     "3. If preprocessing was needed, move those cells to the **Preprocessing records** section above with a markdown header explaining what was done\n",
     "4. Revert this cell before committing — do not accumulate processed layer keys here"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -132,7 +176,14 @@
    "id": "new-working-cell",
    "metadata": {},
    "outputs": [],
-   "source": "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\nprocess_vector_layers(\n    config_path=\"../src/vector_config.yaml\",\n    layer_keys=[\"\"],\n    upload_override=True,\n)"
+   "source": [
+    "# WORKING CELL — edit layer_keys, run, then revert. Do not commit with real values.\n",
+    "process_vector_layers(\n",
+    "    config_path=\"../src/vector_config.yaml\",\n",
+    "    layer_keys=[\"\"],\n",
+    "    upload_override=True,\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/data-processing/src/data_processing/raster_processor.py
+++ b/data-processing/src/data_processing/raster_processor.py
@@ -90,7 +90,12 @@ class RasterProcessor:
 
                 original_nodata = src.nodata
                 if original_nodata is None:
-                    nodata_value = -9999.0 if src.dtypes[0] in ["float32", "float64"] else -9999
+                    if src.dtypes[0] in ["float32", "float64"]:
+                        nodata_value = -9999.0
+                    elif src.dtypes[0] == "uint8":
+                        nodata_value = 0
+                    else:
+                        nodata_value = -9999
                 else:
                     nodata_value = original_nodata
 

--- a/data-processing/src/raster_config.yaml
+++ b/data-processing/src/raster_config.yaml
@@ -959,19 +959,19 @@ layers:
     base_path: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer"
     input_file: "CloudProbability_Armenia_2022.tif"
     style_file: "../Armenia_SymbologyLayers/CloudProbability_Armenia_2022.qml"
-    output_file: "../data/processed/Clean_energy/Armenia/Rasters/CloudProbability.tif"
-    layer_name: "Armenia_CloudProbability"
-    max_zoom: 10
-    tile_format: JPEG
+    vector_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer/armenia_boundary.geojson"
+    output_file: "../data/processed/Clean_energy/Armenia/Rasters/CloudProb.tif"
+    layer_name: "Armenia_CloudProb"
+    max_zoom: 8
 
   armenia_solar_radiation:
     base_path: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer"
-    input_file: "SolarRadiation_Armenia_25m.tif"
+    input_file: "SolarRadiation_Armenia_25m_resampled.tif"
     style_file: "../Armenia_SymbologyLayers/SolarRadiation_Armenia_25m.qml"
+    vector_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/natLayer/armenia_boundary.geojson"
     output_file: "../data/processed/Clean_energy/Armenia/Rasters/SolarRadiation.tif"
     layer_name: "Armenia_SolarRadiation"
-    max_zoom: 10
-    tile_format: JPEG
+    max_zoom: 9
 
   # DRC - Climate Resilience
   drc_agb_2018:

--- a/data-processing/src/vector_config.yaml
+++ b/data-processing/src/vector_config.yaml
@@ -577,22 +577,22 @@ layers:
     input_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/Syunik_cityLevel/Syunik_solar_Building.shp"
     output_file: "../data/processed/Clean_energy/Armenia/Vectors/SolarBuilding.mbtiles"
     layer_name: "Armenia_SolarBuilding"
-    min_zoom: 6
-    max_zoom: 14
+    min_zoom: 10
+    max_zoom: 16
 
   armenia_edges:
     input_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/Syunik_cityLevel/v3_edges.shp"
     output_file: "../data/processed/Clean_energy/Armenia/Vectors/Edges.mbtiles"
     layer_name: "Armenia_Edges"
-    min_zoom: 6
-    max_zoom: 14
+    min_zoom: 10
+    max_zoom: 16
 
   armenia_solar_potential:
     input_file: "../data/raw/Clean_energy/Armenia_Solar/storyArmeniaSolar/Syunik_cityLevel/v4_SolarPotential.shp"
     output_file: "../data/processed/Clean_energy/Armenia/Vectors/SolarPotential.mbtiles"
     layer_name: "Armenia_SolarPotential"
-    min_zoom: 6
-    max_zoom: 14
+    min_zoom: 10
+    max_zoom: 16
 
   # Peru - Climate Resilience
   peru_aoi_peruvian_amazon:


### PR DESCRIPTION
- Remove JPEG tile format from Armenia rasters (JPEG doesn't support transparency, causing black areas outside country boundary)
- Add vector_file clipping to Armenia boundary for cloud probability and solar radiation layers
- Fix uint8 nodata handling in raster_processor (use 0 instead of -9999 which overflows uint8)
- Add solar radiation resampling preprocessing (scale_factor=2)
- Adjust Armenia vector layer zoom ranges (10-16) for city-level detail
- Tune raster max_zoom levels (cloud prob: 8, solar radiation: 9)